### PR TITLE
feat: v0.2.0 — skill management system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,9 +22,9 @@
     },
     "packages/agent": {
       "name": "@mariozechner/pi-agent-core",
-      "version": "0.67.68",
+      "version": "0.1.0",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.67.68",
+        "@mariozechner/pi-ai": "^0.1.0",
         "@sinclair/typebox": "^0.34.41",
       },
       "devDependencies": {
@@ -35,7 +35,7 @@
     },
     "packages/ai": {
       "name": "@mariozechner/pi-ai",
-      "version": "0.67.68",
+      "version": "0.1.0",
       "bin": {
         "pi-ai": "./dist/cli.js",
       },
@@ -63,16 +63,16 @@
     },
     "packages/coding-agent": {
       "name": "@mariozechner/pi-coding-agent",
-      "version": "0.67.68",
+      "version": "0.1.0",
       "bin": {
         "piper": "dist/cli.js",
       },
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.16",
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.67.68",
-        "@mariozechner/pi-ai": "^0.67.68",
-        "@mariozechner/pi-tui": "^0.67.68",
+        "@mariozechner/pi-agent-core": "^0.1.0",
+        "@mariozechner/pi-ai": "^0.1.0",
+        "@mariozechner/pi-tui": "^0.1.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "@sinclair/typebox": "^0.34.41",
         "ajv": "^8.17.1",
@@ -86,6 +86,7 @@
         "ignore": "^7.0.5",
         "marked": "^15.0.12",
         "minimatch": "^10.2.3",
+        "node-pty": "^1.1.0-beta39",
         "proper-lockfile": "^4.1.2",
         "strip-ansi": "^7.1.0",
         "undici": "^7.19.1",
@@ -133,15 +134,15 @@
     },
     "packages/mom": {
       "name": "@mariozechner/pi-mom",
-      "version": "0.67.68",
+      "version": "0.1.0",
       "bin": {
         "mom": "dist/main.js",
       },
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.16",
-        "@mariozechner/pi-agent-core": "^0.67.68",
-        "@mariozechner/pi-ai": "^0.67.68",
-        "@mariozechner/pi-coding-agent": "^0.67.68",
+        "@mariozechner/pi-agent-core": "^0.1.0",
+        "@mariozechner/pi-ai": "^0.1.0",
+        "@mariozechner/pi-coding-agent": "^0.1.0",
         "@sinclair/typebox": "^0.34.0",
         "@slack/socket-mode": "^2.0.0",
         "@slack/web-api": "^7.0.0",
@@ -157,18 +158,18 @@
     },
     "packages/pods": {
       "name": "@mariozechner/pi",
-      "version": "0.67.68",
+      "version": "0.1.0",
       "bin": {
         "pi-pods": "dist/cli.js",
       },
       "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.67.68",
+        "@mariozechner/pi-agent-core": "^0.1.0",
         "chalk": "^5.5.0",
       },
     },
     "packages/tui": {
       "name": "@mariozechner/pi-tui",
-      "version": "0.67.68",
+      "version": "0.1.0",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
@@ -186,12 +187,12 @@
     },
     "packages/web-ui": {
       "name": "@mariozechner/pi-web-ui",
-      "version": "0.67.68",
+      "version": "0.1.0",
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
-        "@mariozechner/pi-agent-core": "^0.67.68",
-        "@mariozechner/pi-ai": "^0.67.68",
-        "@mariozechner/pi-tui": "^0.67.68",
+        "@mariozechner/pi-agent-core": "^0.1.0",
+        "@mariozechner/pi-ai": "^0.1.0",
+        "@mariozechner/pi-tui": "^0.1.0",
         "@sinclair/typebox": "^0.34.41",
         "docx-preview": "^0.3.7",
         "highlight.js": "^11.11.1",
@@ -229,6 +230,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "node-pty",
+  ],
   "overrides": {
     "rimraf": "6.1.2",
   },
@@ -1151,6 +1155,8 @@
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
     "npm-run-path": ["npm-run-path@2.0.2", "", { "dependencies": { "path-key": "^2.0.0" } }, "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -1485,10 +1491,6 @@
 
     "pi-extension-custom-provider-anthropic/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.52.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ=="],
 
-    "pi-web-ui-example/@mariozechner/pi-ai": ["@mariozechner/pi-ai@file:packages/ai", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "devDependencies": { "@types/node": "^24.3.0", "canvas": "^3.2.0", "vitest": "^3.2.4" }, "bin": { "pi-ai": "./dist/cli.js" } }],
-
-    "pi-web-ui-example/@mariozechner/pi-web-ui": ["@mariozechner/pi-web-ui@file:packages/web-ui", { "dependencies": { "@lmstudio/sdk": "^1.5.0", "@mariozechner/pi-ai": "^0.67.68", "@mariozechner/pi-tui": "^0.67.68", "docx-preview": "^0.3.7", "jszip": "^3.10.1", "lucide": "^0.544.0", "ollama": "^0.6.0", "pdfjs-dist": "5.4.394", "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz" }, "devDependencies": { "@mariozechner/mini-lit": "^0.2.0", "@tailwindcss/cli": "^4.0.0-beta.14", "concurrently": "^9.2.1", "typescript": "^5.7.3" }, "peerDependencies": { "@mariozechner/mini-lit": "^0.2.0", "lit": "^3.3.1" } }],
-
     "protobufjs/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1533,10 +1535,6 @@
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "pi-web-ui-example/@mariozechner/pi-ai/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
-
-    "pi-web-ui-example/@mariozechner/pi-web-ui/@mariozechner/pi-ai": ["@mariozechner/pi-ai@file:packages/ai", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "devDependencies": { "@types/node": "^24.3.0", "canvas": "^3.2.0", "vitest": "^3.2.4" }, "bin": { "pi-ai": "./dist/cli.js" } }],
-
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -1549,12 +1547,6 @@
 
     "cli-highlight/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "pi-web-ui-example/@mariozechner/pi-ai/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "pi-web-ui-example/@mariozechner/pi-web-ui/@mariozechner/pi-ai/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
-
     "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "pi-web-ui-example/@mariozechner/pi-web-ui/@mariozechner/pi-ai/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
 	},
 	"overrides": {
 		"rimraf": "6.1.2"
-	}
+	},
+	"trustedDependencies": [
+		"node-pty"
+	]
 }

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `multiplier?: number` field to the `Model<TApi>` interface for representing premium request multipliers on subscription-based providers.
+- Added `COPILOT_MULTIPLIERS` lookup table to `generate-models.ts`, sourced from the [GitHub Copilot billing docs](https://docs.github.com/en/copilot/concepts/billing/copilot-requests#model-multipliers), so running `bun run generate-models` embeds the multiplier for each Copilot model directly in `models.generated.ts`.
+
 ## [0.67.68] - 2026-04-17
 
 ### Fixed

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -53,6 +53,33 @@ const COPILOT_STATIC_HEADERS = {
 	"Copilot-Integration-Id": "vscode-chat",
 } as const;
 
+/**
+ * Premium request multipliers for GitHub Copilot models (paid plans).
+ * Source: https://docs.github.com/en/copilot/concepts/billing/copilot-requests#model-multipliers
+ * Update this table when the docs page changes.
+ */
+const COPILOT_MULTIPLIERS: Record<string, number> = {
+	"claude-haiku-4.5": 0.33,
+	"claude-opus-4.5": 3,
+	"claude-opus-4.6": 3,
+	"claude-opus-4.7": 7.5,
+	"claude-sonnet-4": 1,
+	"claude-sonnet-4.5": 1,
+	"claude-sonnet-4.6": 1,
+	"gemini-2.5-pro": 1,
+	"gemini-3-flash-preview": 0.33,
+	"gemini-3.1-pro-preview": 1,
+	"gpt-4.1": 0,
+	"gpt-4o": 0,
+	"gpt-5-mini": 0,
+	"gpt-5.2": 1,
+	"gpt-5.2-codex": 1,
+	"gpt-5.3-codex": 1,
+	"gpt-5.4": 1,
+	"gpt-5.4-mini": 0.33,
+	"grok-code-fast-1": 0.25,
+};
+
 const AI_GATEWAY_MODELS_URL = "https://ai-gateway.vercel.sh/v1";
 const AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh";
 const ZAI_TOOL_STREAM_UNSUPPORTED_MODELS = new Set(["glm-4.5", "glm-4.5-air", "glm-4.5-flash", "glm-4.5v"]);
@@ -539,6 +566,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						? "openai-responses"
 						: "openai-completions";
 
+				const copilotMultiplier = COPILOT_MULTIPLIERS[modelId];
 				const copilotModel: Model<any> = {
 					id: modelId,
 					name: m.name || modelId,
@@ -556,6 +584,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					contextWindow: m.limit?.context || 128000,
 					maxTokens: m.limit?.output || 8192,
 					headers: { ...COPILOT_STATIC_HEADERS },
+					...(copilotMultiplier !== undefined ? { multiplier: copilotMultiplier } : {}),
 					// compat only applies to openai-completions
 					...(api === "openai-completions" ? {
 						compat: {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -403,6 +403,8 @@ export interface Model<TApi extends Api> {
 	contextWindow: number;
 	maxTokens: number;
 	headers?: Record<string, string>;
+	/** Premium request multiplier for subscription-based providers (e.g. GitHub Copilot). */
+	multiplier?: number;
 	/** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
 	compat?: TApi extends "openai-completions"
 		? OpenAICompletionsCompat

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added GitHub Copilot model multipliers to the model selector. Multiplier values (e.g. `x0`, `x0.33`, `x1`, `x3`) are shown next to each model name so users can see the premium request cost at a glance. The static table is sourced from the [GitHub Copilot billing docs](https://docs.github.com/en/copilot/concepts/billing/copilot-requests#model-multipliers) and is updated at build time via `generate-models`. The live Copilot API is used as the authoritative source when available; the static table is the fallback.
+- Added grouping and sorting in the model selector. Models are sorted by provider then family (e.g. `claude-opus`, `claude-sonnet`, `gpt-5`) and a dim group header appears between families when no search filter is active.
+- Added spacing between sidebar sections. Built-in fields (Model, Thinking, Workspace, Git, Status) and extension-provided sections are now separated by blank lines for easier scanning.
+
+### Fixed
+
+- Fixed the interactive composer to show a dim placeholder when empty and use a padded default left margin instead of rendering flush against the dock border.
+
 ## [0.1.0] - 2026-04-19 - 2026-04-19
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,14 +2,24 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-19
+
 ### Added
 
+- Added `/skills` command for intelligent skill management. Users can now enable/disable skills per-project to reduce context bloat. Disabled skills are hidden from the system prompt (saving context tokens) but remain invokable via `/skill:name`. Selection persists to project `.pi/settings.json`.
+- Added skill selector component with fuzzy search, checkbox list, detail view, and keybinding support. Includes `Ctrl+A` to enable all and `Ctrl+X` to disable all.
+- Added skill count in sidebar showing active vs. total skills (e.g., "Skills: 30/60 active").
 - Added GitHub Copilot model multipliers to the model selector. Multiplier values (e.g. `x0`, `x0.33`, `x1`, `x3`) are shown next to each model name so users can see the premium request cost at a glance. The static table is sourced from the [GitHub Copilot billing docs](https://docs.github.com/en/copilot/concepts/billing/copilot-requests#model-multipliers) and is updated at build time via `generate-models`. The live Copilot API is used as the authoritative source when available; the static table is the fallback.
 - Added grouping and sorting in the model selector. Models are sorted by provider then family (e.g. `claude-opus`, `claude-sonnet`, `gpt-5`) and a dim group header appears between families when no search filter is active.
 - Added spacing between sidebar sections. Built-in fields (Model, Thinking, Workspace, Git, Status) and extension-provided sections are now separated by blank lines for easier scanning.
 
+### Changed
+
+- Changed cursor character from space to π symbol in the interactive editor when focused and empty, matching the piper visual identity.
+
 ### Fixed
 
+- Fixed the thinking selector to remove inconsistent bottom border for UI consistency.
 - Fixed the interactive composer to show a dim placeholder when empty and use a padded default left margin instead of rendering flush against the dock border.
 
 ## [0.1.0] - 2026-04-19 - 2026-04-19

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -44,7 +44,7 @@ Edit directly or use `/settings` for common options.
 | `enableInstallTelemetry` | boolean | `true` | Send an anonymous version/update ping after changelog-detected updates |
 | `doubleEscapeAction` | string | `"tree"` | Action for double-escape: `"tree"`, `"fork"`, or `"none"` |
 | `treeFilterMode` | string | `"default"` | Default filter for `/tree`: `"default"`, `"no-tools"`, `"user-only"`, `"labeled-only"`, `"all"` |
-| `editorPaddingX` | number | `0` | Horizontal padding for input editor (0-3) |
+| `editorPaddingX` | number | `1` | Horizontal padding for input editor (0-3) |
 | `autocompleteMaxVisible` | number | `5` | Max visible items in autocomplete dropdown (3-20) |
 | `showHardwareCursor` | boolean | `false` | Show terminal cursor |
 

--- a/packages/coding-agent/examples/extensions/copilot-budget.ts
+++ b/packages/coding-agent/examples/extensions/copilot-budget.ts
@@ -203,10 +203,6 @@ export function buildCopilotSidebarSections(data: CopilotUsageData | null): Exte
 			value: `${data.percent}%`,
 			color: getBudgetColor(data.percent),
 		},
-		{
-			label: "Premium",
-			value: data.unlimited ? `${data.used} used (unlimited)` : `${data.used} / ${data.entitlement} requests`,
-		},
 	];
 
 	if (data.overageCount > 0) {

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -59,6 +59,7 @@
 		"ignore": "^7.0.5",
 		"marked": "^15.0.12",
 		"minimatch": "^10.2.3",
+		"node-pty": "^1.1.0-beta39",
 		"proper-lockfile": "^4.1.2",
 		"strip-ansi": "^7.1.0",
 		"undici": "^7.19.1",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2544,7 +2544,7 @@ export class AgentSession {
 	async executeBash(
 		command: string,
 		onChunk?: (chunk: string) => void,
-		options?: { excludeFromContext?: boolean; operations?: BashOperations },
+		options?: { excludeFromContext?: boolean; operations?: BashOperations; userShell?: boolean },
 	): Promise<BashResult> {
 		this._bashAbortController = new AbortController();
 
@@ -2556,7 +2556,7 @@ export class AgentSession {
 			const result = await executeBashWithOperations(
 				resolvedCommand,
 				this.sessionManager.getCwd(),
-				options?.operations ?? createLocalBashOperations(),
+				options?.operations ?? createLocalBashOperations({ mode: options?.userShell ? "user" : "tool" }),
 				{
 					onChunk,
 					signal: this._bashAbortController.signal,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -903,10 +903,12 @@ export class AgentSession {
 			loaderAppendSystemPrompt.length > 0 ? loaderAppendSystemPrompt.join("\n\n") : undefined;
 		const loadedSkills = this._resourceLoader.getSkills().skills;
 		const loadedContextFiles = this._resourceLoader.getAgentsFiles().agentsFiles;
+		const disabledSkills = this.settingsManager.getDisabledSkills();
 
 		return buildSystemPrompt({
 			cwd: this._cwd,
 			skills: loadedSkills,
+			disabledSkills,
 			contextFiles: loadedContextFiles,
 			customPrompt: loaderSystemPrompt,
 			appendSystemPrompt,
@@ -1356,6 +1358,11 @@ export class AgentSession {
 
 	get resourceLoader(): ResourceLoader {
 		return this._resourceLoader;
+	}
+
+	rebuildSystemPrompt(): void {
+		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+		this.agent.state.systemPrompt = this._baseSystemPrompt;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -19,6 +19,9 @@ export interface AppKeybindings {
 	"app.model.cycleForward": true;
 	"app.model.cycleBackward": true;
 	"app.model.select": true;
+	"app.skills.select": true;
+	"app.skills.enableAll": true;
+	"app.skills.disableAll": true;
 	"app.tools.expand": true;
 	"app.thinking.toggle": true;
 	"app.session.toggleNamedFilter": true;
@@ -76,6 +79,9 @@ export const KEYBINDINGS = {
 		description: "Cycle to previous model",
 	},
 	"app.model.select": { defaultKeys: "ctrl+l", description: "Open model selector" },
+	"app.skills.select": { defaultKeys: [], description: "Open skill selector" },
+	"app.skills.enableAll": { defaultKeys: "ctrl+a", description: "Enable all skills (in skill selector)" },
+	"app.skills.disableAll": { defaultKeys: "ctrl+x", description: "Disable all skills (in skill selector)" },
 	"app.tools.expand": { defaultKeys: "ctrl+o", description: "Toggle tool output" },
 	"app.thinking.toggle": {
 		defaultKeys: "ctrl+t",

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -35,6 +35,7 @@ export interface ResourceLoader {
 	getSystemPrompt(): string | undefined;
 	getAppendSystemPrompt(): string[];
 	extendResources(paths: ResourceExtensionPaths): void;
+	setCwd?(cwd: string): void;
 	reload(): Promise<void>;
 }
 
@@ -276,6 +277,20 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	getAppendSystemPrompt(): string[] {
 		return this.appendSystemPrompt;
+	}
+
+	setCwd(cwd: string): void {
+		const resolvedCwd = resolve(cwd);
+		if (resolvedCwd === this.cwd) {
+			return;
+		}
+
+		this.cwd = resolvedCwd;
+		this.packageManager = new DefaultPackageManager({
+			cwd: this.cwd,
+			agentDir: this.agentDir,
+			settingsManager: this.settingsManager,
+		});
 	}
 
 	extendResources(paths: ResourceExtensionPaths): void {

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -786,6 +786,31 @@ export class SessionManager {
 		return this.cwd;
 	}
 
+	setCwd(cwd: string): void {
+		const resolvedCwd = resolve(cwd);
+		if (resolvedCwd === this.cwd) {
+			return;
+		}
+
+		this.cwd = resolvedCwd;
+
+		const headerIndex = this.fileEntries.findIndex((entry) => entry.type === "session");
+		if (headerIndex === -1) {
+			return;
+		}
+
+		const header = this.fileEntries[headerIndex];
+		if (header?.type !== "session") {
+			return;
+		}
+
+		this.fileEntries[headerIndex] = {
+			...header,
+			cwd: resolvedCwd,
+		};
+		this._rewriteFile();
+	}
+
 	getSessionDir(): string {
 		return this.sessionDir;
 	}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -91,7 +91,7 @@ export interface Settings {
 	doubleEscapeAction?: "fork" | "tree" | "none"; // Action for double-escape with empty editor (default: "tree")
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default filter when opening /tree
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
-	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
+	editorPaddingX?: number; // Horizontal padding for input editor (default: 1)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
@@ -945,7 +945,7 @@ export class SettingsManager {
 	}
 
 	getEditorPaddingX(): number {
-		return this.settings.editorPaddingX ?? 0;
+		return this.settings.editorPaddingX ?? 1;
 	}
 
 	setEditorPaddingX(padding: number): void {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -133,6 +133,7 @@ export type SettingsScope = "global" | "project";
 
 export interface SettingsStorage {
 	withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
+	setCwd?(cwd: string, agentDir?: string): void;
 }
 
 export interface SettingsError {
@@ -141,10 +142,18 @@ export interface SettingsError {
 }
 
 export class FileSettingsStorage implements SettingsStorage {
+	private agentDir: string;
 	private globalSettingsPath: string;
 	private projectSettingsPath: string;
 
 	constructor(cwd: string = process.cwd(), agentDir: string = getAgentDir()) {
+		this.agentDir = agentDir;
+		this.globalSettingsPath = join(agentDir, "settings.json");
+		this.projectSettingsPath = join(cwd, CONFIG_DIR_NAME, "settings.json");
+	}
+
+	setCwd(cwd: string, agentDir: string = this.agentDir): void {
+		this.agentDir = agentDir;
 		this.globalSettingsPath = join(agentDir, "settings.json");
 		this.projectSettingsPath = join(cwd, CONFIG_DIR_NAME, "settings.json");
 	}
@@ -222,6 +231,8 @@ export class InMemorySettingsStorage implements SettingsStorage {
 			}
 		}
 	}
+
+	setCwd(): void {}
 }
 
 export class SettingsManager {
@@ -287,6 +298,10 @@ export class SettingsManager {
 	static inMemory(settings: Partial<Settings> = {}): SettingsManager {
 		const storage = new InMemorySettingsStorage();
 		return new SettingsManager(storage, settings, {});
+	}
+
+	setCwd(cwd: string, agentDir: string = getAgentDir()): void {
+		this.storage.setCwd?.(cwd, agentDir);
 	}
 
 	private static loadFromStorage(storage: SettingsStorage, scope: SettingsScope): Settings {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -85,6 +85,7 @@ export interface Settings {
 	prompts?: string[]; // Array of local prompt template paths or directories
 	themes?: string[]; // Array of local theme file paths or directories
 	enableSkillCommands?: boolean; // default: true - register skills as /skill:name commands
+	disabledSkills?: string[]; // Skill names hidden from system prompt (still invokable via /skill:name)
 	terminal?: TerminalSettings;
 	images?: ImageSettings;
 	enabledModels?: string[]; // Model patterns for cycling (same format as --models CLI flag)
@@ -855,6 +856,17 @@ export class SettingsManager {
 		this.globalSettings.enableSkillCommands = enabled;
 		this.markModified("enableSkillCommands");
 		this.save();
+	}
+
+	getDisabledSkills(): string[] {
+		return [...(this.settings.disabledSkills ?? [])];
+	}
+
+	setProjectDisabledSkills(names: string[]): void {
+		const projectSettings = structuredClone(this.projectSettings);
+		projectSettings.disabledSkills = names;
+		this.markProjectModified("disabledSkills");
+		this.saveProjectSettings(projectSettings);
 	}
 
 	getThinkingBudgets(): ThinkingBudgetsSettings | undefined {

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -336,8 +336,9 @@ function loadSkillFromFile(
  * Skills with disableModelInvocation=true are excluded from the prompt
  * (they can only be invoked explicitly via /skill:name commands).
  */
-export function formatSkillsForPrompt(skills: Skill[]): string {
-	const visibleSkills = skills.filter((s) => !s.disableModelInvocation);
+export function formatSkillsForPrompt(skills: Skill[], disabledSkills: string[] = []): string {
+	const disabledSet = new Set(disabledSkills);
+	const visibleSkills = skills.filter((s) => !s.disableModelInvocation && !disabledSet.has(s.name));
 
 	if (visibleSkills.length === 0) {
 		return "";

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -18,6 +18,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
 	{ name: "thinking", description: "Set thinking level or open selector UI" },
+	{ name: "skills", description: "Enable/disable skills for context injection" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
 	{ name: "import", description: "Import and resume a session from a JSONL file" },

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -17,6 +17,7 @@ export interface BuiltinSlashCommand {
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
+	{ name: "thinking", description: "Set thinking level or open selector UI" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
 	{ name: "import", description: "Import and resume a session from a JSONL file" },

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -22,6 +22,8 @@ export interface BuildSystemPromptOptions {
 	contextFiles?: Array<{ path: string; content: string }>;
 	/** Pre-loaded skills. */
 	skills?: Skill[];
+	/** Skill names to hide from prompt (still invokable via /skill:name). */
+	disabledSkills?: string[];
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -35,6 +37,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		cwd,
 		contextFiles: providedContextFiles,
 		skills: providedSkills,
+		disabledSkills,
 	} = options;
 	const resolvedCwd = cwd ?? process.cwd();
 	const promptCwd = resolvedCwd.replace(/\\/g, "/");
@@ -69,7 +72,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		// Append skills section (only if read tool is available)
 		const customPromptHasRead = !selectedTools || selectedTools.includes("read");
 		if (customPromptHasRead && skills.length > 0) {
-			prompt += formatSkillsForPrompt(skills);
+			prompt += formatSkillsForPrompt(skills, disabledSkills);
 		}
 
 		// Add date and working directory last
@@ -161,7 +164,7 @@ ${APP_NAME} documentation (read only when the user asks about ${APP_NAME} itself
 
 	// Append skills section (only if read tool is available)
 	if (hasRead && skills.length > 0) {
-		prompt += formatSkillsForPrompt(skills);
+		prompt += formatSkillsForPrompt(skills, disabledSkills);
 	}
 
 	// Add date and working directory last

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -14,6 +14,7 @@ import {
 	getShellConfig,
 	getShellEnv,
 	killProcessTree,
+	type ShellExecutionMode,
 	trackDetachedChildPid,
 	untrackDetachedChildPid,
 } from "../../utils/shell.js";
@@ -72,11 +73,11 @@ export interface BashOperations {
  * This is useful for extensions that intercept user_bash and still want pi's
  * standard local shell behavior while wrapping or rewriting commands.
  */
-export function createLocalBashOperations(): BashOperations {
+export function createLocalBashOperations(options?: { mode?: ShellExecutionMode }): BashOperations {
 	return {
 		exec: (command, cwd, { onData, signal, timeout, env }) => {
 			return new Promise((resolve, reject) => {
-				const { shell, args } = getShellConfig();
+				const { shell, args } = getShellConfig(options?.mode ?? "tool");
 				if (!existsSync(cwd)) {
 					reject(new Error(`Working directory does not exist: ${cwd}\nCannot execute bash commands.`));
 					return;

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -3,7 +3,7 @@ import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
 import { Text } from "@mariozechner/pi-tui";
 import { type Static, Type } from "@sinclair/typebox";
 import { constants } from "fs";
-import { access as fsAccess, readFile as fsReadFile } from "fs/promises";
+import { access as fsAccess, readFile as fsReadFile, stat as fsStat } from "fs/promises";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { getLanguageFromPath, highlightCode } from "../../modes/interactive/theme/theme.js";
 import { formatDimensionNote, resizeImage } from "../../utils/image-resize.js";
@@ -150,6 +150,20 @@ export function createReadToolDefinition(
 							// Check if file exists and is readable.
 							await ops.access(absolutePath);
 							if (aborted) return;
+							// Detect directories early and return a useful message instead of EISDIR.
+							const statResult = await fsStat(absolutePath).catch(() => null);
+							if (statResult?.isDirectory()) {
+								resolve({
+									content: [
+										{
+											type: "text",
+											text: `${absolutePath} is a directory, not a file. Use Glob to find files or Bash (ls) to list contents.`,
+										},
+									],
+									details: undefined,
+								});
+								return;
+							}
 							const mimeType = ops.detectImageMimeType ? await ops.detectImageMimeType(absolutePath) : undefined;
 							let content: (TextContent | ImageContent)[];
 							let details: ReadToolDetails | undefined;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -19,6 +19,7 @@ import { getAgentDir, getModelsPath, VERSION } from "./config.js";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.js";
 import {
 	type AgentSessionRuntimeDiagnostic,
+	type AgentSessionServices,
 	createAgentSessionFromServices,
 	createAgentSessionServices,
 } from "./core/agent-session-services.js";
@@ -518,32 +519,39 @@ export async function main(args: string[], options?: MainOptions) {
 	const resolvedPromptTemplatePaths = resolveCliPaths(cwd, parsed.promptTemplates);
 	const resolvedThemePaths = resolveCliPaths(cwd, parsed.themes);
 	const authStorage = AuthStorage.create();
+	let cachedServices: AgentSessionServices | undefined;
 	const createRuntime: CreateAgentSessionRuntimeFactory = async ({
 		cwd,
 		agentDir,
 		sessionManager,
 		sessionStartEvent,
 	}) => {
-		const services = await createAgentSessionServices({
-			cwd,
-			agentDir,
-			authStorage,
-			extensionFlagValues: parsed.unknownFlags,
-			resourceLoaderOptions: {
-				additionalExtensionPaths: resolvedExtensionPaths,
-				additionalSkillPaths: resolvedSkillPaths,
-				additionalPromptTemplatePaths: resolvedPromptTemplatePaths,
-				additionalThemePaths: resolvedThemePaths,
-				noExtensions: parsed.noExtensions,
-				noSkills: parsed.noSkills,
-				noPromptTemplates: parsed.noPromptTemplates,
-				noThemes: parsed.noThemes,
-				noContextFiles: parsed.noContextFiles,
-				systemPrompt: parsed.systemPrompt,
-				appendSystemPrompt: parsed.appendSystemPrompt,
-				extensionFactories: options?.extensionFactories,
-			},
-		});
+		let services: AgentSessionServices;
+		if (cachedServices && cachedServices.cwd === cwd) {
+			services = cachedServices;
+		} else {
+			services = await createAgentSessionServices({
+				cwd,
+				agentDir,
+				authStorage,
+				extensionFlagValues: parsed.unknownFlags,
+				resourceLoaderOptions: {
+					additionalExtensionPaths: resolvedExtensionPaths,
+					additionalSkillPaths: resolvedSkillPaths,
+					additionalPromptTemplatePaths: resolvedPromptTemplatePaths,
+					additionalThemePaths: resolvedThemePaths,
+					noExtensions: parsed.noExtensions,
+					noSkills: parsed.noSkills,
+					noPromptTemplates: parsed.noPromptTemplates,
+					noThemes: parsed.noThemes,
+					noContextFiles: parsed.noContextFiles,
+					systemPrompt: parsed.systemPrompt,
+					appendSystemPrompt: parsed.appendSystemPrompt,
+					extensionFactories: options?.extensionFactories,
+				},
+			});
+			cachedServices = services;
+		}
 		const { settingsManager, modelRegistry, resourceLoader } = services;
 		const diagnostics: AgentSessionRuntimeDiagnostic[] = [
 			...services.diagnostics,
@@ -683,6 +691,7 @@ export async function main(args: string[], options?: MainOptions) {
 		printTimings();
 		await runRpcMode(runtime);
 	} else if (appMode === "interactive") {
+		let startupNote: string | undefined;
 		if (scopedModels.length > 0 && (parsed.verbose || !settingsManager.getQuietStartup())) {
 			const modelList = scopedModels
 				.map((sm) => {
@@ -690,7 +699,7 @@ export async function main(args: string[], options?: MainOptions) {
 					return `${sm.model.id}${thinkingStr}`;
 				})
 				.join(", ");
-			console.log(chalk.dim(`Model scope: ${modelList} ${chalk.gray("(Ctrl+P to cycle)")}`));
+			startupNote = `Model scope: ${modelList} (Ctrl+P to cycle)`;
 		}
 
 		const interactiveMode = new InteractiveMode(runtime, {
@@ -700,6 +709,7 @@ export async function main(args: string[], options?: MainOptions) {
 			initialImages,
 			initialMessages: parsed.messages,
 			verbose: parsed.verbose,
+			startupNote,
 		});
 		if (startupBenchmark) {
 			await interactiveMode.init();

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -33,10 +33,6 @@ function removeLowerBorder(rendered: string[]): string[] {
 	return rendered;
 }
 
-function withBottomMargin(rendered: string[], width: number): string[] {
-	return [...rendered, " ".repeat(Math.max(0, width))];
-}
-
 function withGapBeforeAutocomplete(rendered: string[], width: number, autocompleteLineCount: number): string[] {
 	if (autocompleteLineCount <= 0 || rendered.length <= autocompleteLineCount) {
 		return rendered;
@@ -103,7 +99,7 @@ export class CustomEditor extends Editor {
 			if (this.isShowingAutocomplete()) {
 				return withGapBeforeAutocomplete(withoutLowerBorder, width, this.getAutocompleteLineCount(width));
 			}
-			return withBottomMargin(withoutLowerBorder, width);
+			return withoutLowerBorder;
 		}
 
 		const maxPadding = Math.max(0, Math.floor((width - 1) / 2));
@@ -118,7 +114,7 @@ export class CustomEditor extends Editor {
 		const cursorPrefix = this.focused ? `${CURSOR_MARKER}\x1b[7m \x1b[0m` : "";
 
 		rendered[1] = `${leftPadding}${cursorPrefix}${truncatedPlaceholder}${trailingSpaces}${rightPadding}`;
-		return withBottomMargin(removeLowerBorder(rendered), width);
+		return removeLowerBorder(rendered);
 	}
 
 	handleInput(data: string): void {

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -14,6 +14,42 @@ export interface CustomEditorOptions extends EditorOptions {
 	placeholderStyle?: (text: string) => string;
 }
 
+function stripTerminalSequences(line: string): string {
+	return line.replace(/\x1b(?:\[[0-9;?]*[ -/]*[@-~]|\].*?(?:\x07|\x1b\\)|_.*?\x07)/g, "");
+}
+
+function isEditorBorderLine(line: string): boolean {
+	const plain = stripTerminalSequences(line).trim();
+	return plain.length > 0 && /^[─↑↓0-9 more]+$/.test(plain);
+}
+
+function removeLowerBorder(rendered: string[]): string[] {
+	for (let i = rendered.length - 1; i >= 0; i--) {
+		if (isEditorBorderLine(rendered[i] ?? "")) {
+			return [...rendered.slice(0, i), ...rendered.slice(i + 1)];
+		}
+	}
+
+	return rendered;
+}
+
+function withBottomMargin(rendered: string[], width: number): string[] {
+	return [...rendered, " ".repeat(Math.max(0, width))];
+}
+
+function withGapBeforeAutocomplete(rendered: string[], width: number, autocompleteLineCount: number): string[] {
+	if (autocompleteLineCount <= 0 || rendered.length <= autocompleteLineCount) {
+		return rendered;
+	}
+
+	const autocompleteStart = rendered.length - autocompleteLineCount;
+	return [
+		...rendered.slice(0, autocompleteStart),
+		" ".repeat(Math.max(0, width)),
+		...rendered.slice(autocompleteStart),
+	];
+}
+
 /**
  * Custom editor that handles app-level keybindings for coding-agent.
  */
@@ -51,10 +87,23 @@ export class CustomEditor extends Editor {
 		}
 	}
 
+	private getAutocompleteLineCount(width: number): number {
+		const maxPadding = Math.max(0, Math.floor((width - 1) / 2));
+		const paddingX = Math.min(this.getPaddingX(), maxPadding);
+		const contentWidth = Math.max(1, width - paddingX * 2);
+		const autocompleteList = (this as unknown as { autocompleteList?: { render: (width: number) => string[] } })
+			.autocompleteList;
+		return autocompleteList?.render(contentWidth).length ?? 0;
+	}
+
 	override render(width: number): string[] {
 		const rendered = super.render(width);
+		const withoutLowerBorder = removeLowerBorder(rendered);
 		if (!this.placeholder || this.getText().length > 0 || this.isShowingAutocomplete() || rendered.length < 3) {
-			return rendered;
+			if (this.isShowingAutocomplete()) {
+				return withGapBeforeAutocomplete(withoutLowerBorder, width, this.getAutocompleteLineCount(width));
+			}
+			return withBottomMargin(withoutLowerBorder, width);
 		}
 
 		const maxPadding = Math.max(0, Math.floor((width - 1) / 2));
@@ -69,7 +118,7 @@ export class CustomEditor extends Editor {
 		const cursorPrefix = this.focused ? `${CURSOR_MARKER}\x1b[7m \x1b[0m` : "";
 
 		rendered[1] = `${leftPadding}${cursorPrefix}${truncatedPlaceholder}${trailingSpaces}${rightPadding}`;
-		return rendered;
+		return withBottomMargin(removeLowerBorder(rendered), width);
 	}
 
 	handleInput(data: string): void {

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -1,11 +1,26 @@
-import { Editor, type EditorOptions, type EditorTheme, type TUI } from "@mariozechner/pi-tui";
+import {
+	CURSOR_MARKER,
+	Editor,
+	type EditorOptions,
+	type EditorTheme,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@mariozechner/pi-tui";
 import type { AppKeybinding, KeybindingsManager } from "../../../core/keybindings.js";
+
+export interface CustomEditorOptions extends EditorOptions {
+	placeholder?: string;
+	placeholderStyle?: (text: string) => string;
+}
 
 /**
  * Custom editor that handles app-level keybindings for coding-agent.
  */
 export class CustomEditor extends Editor {
 	private keybindings: KeybindingsManager;
+	private placeholder?: string;
+	private placeholderStyle: (text: string) => string;
 	public actionHandlers: Map<AppKeybinding, () => void> = new Map();
 
 	// Special handlers that can be dynamically replaced
@@ -15,9 +30,11 @@ export class CustomEditor extends Editor {
 	/** Handler for extension-registered shortcuts. Returns true if handled. */
 	public onExtensionShortcut?: (data: string) => boolean;
 
-	constructor(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager, options?: EditorOptions) {
+	constructor(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager, options: CustomEditorOptions = {}) {
 		super(tui, theme, options);
 		this.keybindings = keybindings;
+		this.placeholder = options.placeholder;
+		this.placeholderStyle = options.placeholderStyle ?? ((text) => text);
 	}
 
 	/**
@@ -25,6 +42,34 @@ export class CustomEditor extends Editor {
 	 */
 	onAction(action: AppKeybinding, handler: () => void): void {
 		this.actionHandlers.set(action, handler);
+	}
+
+	setPlaceholder(placeholder?: string): void {
+		if (this.placeholder !== placeholder) {
+			this.placeholder = placeholder;
+			this.tui.requestRender();
+		}
+	}
+
+	override render(width: number): string[] {
+		const rendered = super.render(width);
+		if (!this.placeholder || this.getText().length > 0 || this.isShowingAutocomplete() || rendered.length < 3) {
+			return rendered;
+		}
+
+		const maxPadding = Math.max(0, Math.floor((width - 1) / 2));
+		const paddingX = Math.min(this.getPaddingX(), maxPadding);
+		const contentWidth = Math.max(1, width - paddingX * 2);
+		const leftPadding = " ".repeat(paddingX);
+		const rightPadding = leftPadding;
+		const reservedCursorWidth = this.focused ? 1 : 0;
+		const placeholderWidth = Math.max(0, contentWidth - reservedCursorWidth);
+		const truncatedPlaceholder = truncateToWidth(this.placeholderStyle(this.placeholder), placeholderWidth);
+		const trailingSpaces = " ".repeat(Math.max(0, placeholderWidth - visibleWidth(truncatedPlaceholder)));
+		const cursorPrefix = this.focused ? `${CURSOR_MARKER}\x1b[7m \x1b[0m` : "";
+
+		rendered[1] = `${leftPadding}${cursorPrefix}${truncatedPlaceholder}${trailingSpaces}${rightPadding}`;
+		return rendered;
 	}
 
 	handleInput(data: string): void {

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -23,6 +23,7 @@ export { SessionSelectorComponent } from "./session-selector.js";
 export { type SettingsCallbacks, type SettingsConfig, SettingsSelectorComponent } from "./settings-selector.js";
 export { ShowImagesSelectorComponent } from "./show-images-selector.js";
 export { SkillInvocationMessageComponent } from "./skill-invocation-message.js";
+export { SkillSelectorComponent } from "./skill-selector.js";
 export { ThemeSelectorComponent } from "./theme-selector.js";
 export { ThinkingSelectorComponent } from "./thinking-selector.js";
 export { ToolExecutionComponent, type ToolExecutionOptions } from "./tool-execution.js";

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -11,6 +11,11 @@ import {
 } from "@mariozechner/pi-tui";
 import type { ModelRegistry } from "../../../core/model-registry.js";
 import type { SettingsManager } from "../../../core/settings-manager.js";
+import {
+	COPILOT_MULTIPLIERS,
+	type CopilotModelPolicy,
+	fetchCopilotModelPolicies,
+} from "../../../utils/copilot-model-policies.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
@@ -54,6 +59,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private modelRegistry: ModelRegistry;
 	private onSelectCallback: (model: Model<any>) => void;
 	private onCancelCallback: () => void;
+	private copilotPolicies: Map<string, CopilotModelPolicy> = new Map();
 	private errorMessage?: string;
 	private tui: TUI;
 	private scopedModels: ReadonlyArray<ScopedModelItem>;
@@ -163,6 +169,31 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			return;
 		}
 
+		// Fetch Copilot model policies (multiplier + disabled) if Copilot models are available
+		const copilotModel = models.find((m) => m.provider === "github-copilot");
+		if (copilotModel) {
+			const auth = await this.modelRegistry.getApiKeyAndHeaders(copilotModel.model);
+			if (auth.ok && auth.apiKey) {
+				this.copilotPolicies = await fetchCopilotModelPolicies(auth.apiKey, copilotModel.model.baseUrl);
+				if (this.copilotPolicies.size > 0) {
+					models = models.filter((m) => {
+						if (m.provider !== "github-copilot") return true;
+						const policy = this.copilotPolicies.get(m.id);
+						return !policy?.disabled;
+					});
+				}
+			}
+
+			// Filter out Copilot models with no known multiplier — unlisted models are
+			// deprecated or not yet available. x0 is valid (free included models).
+			models = models.filter((m) => {
+				if (m.provider !== "github-copilot") return true;
+				const apiMultiplier = this.copilotPolicies.get(m.id)?.multiplier;
+				const staticMultiplier = COPILOT_MULTIPLIERS[m.id];
+				return apiMultiplier !== undefined || staticMultiplier !== undefined;
+			});
+		}
+
 		this.allModels = this.sortModels(models);
 		this.scopedModels = this.scopedModels.map((scoped) => {
 			const refreshed = this.modelRegistry.find(scoped.model.provider, scoped.model.id);
@@ -180,15 +211,28 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			currentIndex >= 0 ? currentIndex : Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
 	}
 
+	private getModelFamily(id: string): string {
+		const parts = id.split("-");
+		const familyParts: string[] = [];
+		for (const part of parts) {
+			if (/^\d/.test(part)) break;
+			familyParts.push(part);
+		}
+		return familyParts.join("-") || id;
+	}
+
 	private sortModels(models: ModelItem[]): ModelItem[] {
 		const sorted = [...models];
-		// Sort: current model first, then by provider
 		sorted.sort((a, b) => {
 			const aIsCurrent = modelsAreEqual(this.currentModel, a.model);
 			const bIsCurrent = modelsAreEqual(this.currentModel, b.model);
 			if (aIsCurrent && !bIsCurrent) return -1;
 			if (!aIsCurrent && bIsCurrent) return 1;
-			return a.provider.localeCompare(b.provider);
+			const providerCmp = a.provider.localeCompare(b.provider);
+			if (providerCmp !== 0) return providerCmp;
+			const familyCmp = this.getModelFamily(a.id).localeCompare(this.getModelFamily(b.id));
+			if (familyCmp !== 0) return familyCmp;
+			return a.id.localeCompare(b.id);
 		});
 		return sorted;
 	}
@@ -237,6 +281,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		);
 		const endIndex = Math.min(startIndex + maxVisible, this.filteredModels.length);
 
+		// Group headers are shown only when the list is unfiltered
+		const isFiltered = this.filteredModels.length < this.activeModels.length;
+		const showGroups = !isFiltered && this.filteredModels.length > 0;
+
 		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
 			const item = this.filteredModels[i];
@@ -245,18 +293,38 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			const isSelected = i === this.selectedIndex;
 			const isCurrent = modelsAreEqual(this.currentModel, item.model);
 
+			if (showGroups) {
+				const prevItem = i > 0 ? this.filteredModels[i - 1] : undefined;
+				const family = this.getModelFamily(item.id);
+				const prevFamily = prevItem ? this.getModelFamily(prevItem.id) : undefined;
+				const prevProvider = prevItem?.provider;
+				if (family !== prevFamily || item.provider !== prevProvider) {
+					if (i > startIndex) {
+						this.listContainer.addChild(new Text("", 0, 0));
+					}
+					this.listContainer.addChild(new Text(theme.fg("dim", `  ${family}`), 0, 0));
+				}
+			}
+
+			const copilotPolicy = item.provider === "github-copilot" ? this.copilotPolicies.get(item.id) : undefined;
+			const multiplier =
+				item.provider === "github-copilot"
+					? (copilotPolicy?.multiplier ?? COPILOT_MULTIPLIERS[item.id])
+					: undefined;
+			const multiplierBadge = multiplier !== undefined ? theme.fg("dim", ` (x${multiplier})`) : "";
+
 			let line = "";
 			if (isSelected) {
 				const prefix = theme.fg("accent", "→ ");
 				const modelText = `${item.id}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
-				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${checkmark}`;
+				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${multiplierBadge}${checkmark}`;
 			} else {
-				const modelText = `  ${item.id}`;
+				const modelText = `    ${item.id}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
-				line = `${modelText} ${providerBadge}${checkmark}`;
+				line = `${modelText} ${providerBadge}${multiplierBadge}${checkmark}`;
 			}
 
 			this.listContainer.addChild(new Text(line, 0, 0));

--- a/packages/coding-agent/src/modes/interactive/components/shell-dock.ts
+++ b/packages/coding-agent/src/modes/interactive/components/shell-dock.ts
@@ -62,18 +62,18 @@ export class ShellDockComponent implements Component {
 			}
 			const availableForTransient = Math.max(0, maxHeight - fixedLines.length);
 			const clippedTransient = transientLines.slice(0, availableForTransient);
-			return [...hintLines, ...clippedTransient, ...footerLines];
+			return [...clippedTransient, ...hintLines, ...footerLines];
 		}
 
 		const editorLines = this.editor.render(width);
 		const belowEditorLines = this.belowEditor.render(width);
-		const fixedLines = [...hintLines, ...editorLines, ...belowEditorLines, ...footerLines];
+		const fixedLines = [...editorLines, ...hintLines, ...belowEditorLines, ...footerLines];
 		if (fixedLines.length >= maxHeight) {
 			return fixedLines.slice(Math.max(0, fixedLines.length - maxHeight));
 		}
 
 		const availableForTransient = Math.max(0, maxHeight - fixedLines.length);
 		const clippedTransient = transientLines.slice(0, availableForTransient);
-		return [...hintLines, ...clippedTransient, ...editorLines, ...belowEditorLines, ...footerLines];
+		return [...clippedTransient, ...editorLines, ...hintLines, ...belowEditorLines, ...footerLines];
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/shell-sidebar.ts
+++ b/packages/coding-agent/src/modes/interactive/components/shell-sidebar.ts
@@ -180,19 +180,20 @@ export class ShellSidebarComponent implements Component {
 			}
 			return lines;
 		};
-		const renderExtensionSections = (sections: SidebarDisplaySection[]): string[] =>
-			sections.flatMap((section) => {
+		const renderExtensionSections = (sections: SidebarDisplaySection[]): string[] => {
+			const rendered: string[][] = [];
+			for (const section of sections) {
 				const label = normalizeSectionText(section.label);
 				const value = truncateSectionValue(section.value);
 				if (!label || !value) {
-					return [];
+					continue;
 				}
 				const tone = resolveSidebarColor(section.color);
 				const percent = parsePercentText(value);
 				if (percent !== null) {
 					const meterTone = tone ?? getContextTone(percent);
 					const meterWidth = Math.max(8, Math.min(18, contentWidth - 8));
-					return [
+					rendered.push([
 						...wrapLine(theme.fg("muted", label)),
 						...wrapLine(
 							`${theme.fg(meterTone, renderCompactMeter(percent, meterWidth))} ${theme.fg(
@@ -200,11 +201,19 @@ export class ShellSidebarComponent implements Component {
 								formatPercent(percent),
 							)}`,
 						),
-					];
+					]);
+				} else {
+					const coloredValue = tone ? theme.fg(tone, value) : theme.fg("text", value);
+					rendered.push(labeledSection(label, coloredValue));
 				}
-				const coloredValue = tone ? theme.fg(tone, value) : theme.fg("text", value);
-				return labeledSection(label, coloredValue);
-			});
+			}
+			const result: string[] = [];
+			for (let i = 0; i < rendered.length; i++) {
+				if (i > 0) result.push(blank);
+				result.push(...rendered[i]);
+			}
+			return result;
+		};
 
 		const orderedSections = [...this.resourceSections].sort(
 			(a, b) =>
@@ -224,6 +233,7 @@ export class ShellSidebarComponent implements Component {
 		const headerGroup: string[] = [];
 		if (sessionTitle) {
 			headerGroup.push(...wrapLine(theme.bold(theme.fg("accent", sessionTitle))));
+			headerGroup.push(blank);
 		}
 
 		const model = this.session.model;
@@ -238,6 +248,7 @@ export class ShellSidebarComponent implements Component {
 		const thinkingLevel = this.session.thinkingLevel;
 		const thinkingTone = model?.reasoning ? getThinkingTone(thinkingLevel) : "muted";
 		const thinkingValue = model?.reasoning ? thinkingLevel : "unsupported";
+		headerGroup.push(blank);
 		headerGroup.push(...labeledSection("Thinking", theme.fg(thinkingTone, thinkingValue)));
 		topGroups.push(headerGroup);
 
@@ -299,6 +310,7 @@ export class ShellSidebarComponent implements Component {
 
 		const branch = this.footerData.getGitBranch();
 		if (branch) {
+			workspaceGroup.push(blank);
 			workspaceGroup.push(...labeledSection("Git", theme.fg("text", branch)));
 		}
 
@@ -306,11 +318,15 @@ export class ShellSidebarComponent implements Component {
 			.map((status) => status.trim())
 			.filter(Boolean);
 		const statusValue = statuses.length > 0 ? truncateSectionValue(statuses.join(", ")) : "ready";
+		workspaceGroup.push(blank);
 		workspaceGroup.push(
 			...labeledSection("Status", theme.fg(statuses.length > 0 ? "warning" : "success", statusValue)),
 		);
-		workspaceGroup.push(...renderExtensionSections(workspaceSections));
-		workspaceGroup.push(...renderExtensionSections(overflowSections));
+		const workspaceExtSections = renderExtensionSections([...workspaceSections, ...overflowSections]);
+		if (workspaceExtSections.length > 0) {
+			workspaceGroup.push(blank);
+			workspaceGroup.push(...workspaceExtSections);
+		}
 		bottomGroups.push(workspaceGroup);
 
 		const topLines = joinGroups(topGroups);

--- a/packages/coding-agent/src/modes/interactive/components/shell-sidebar.ts
+++ b/packages/coding-agent/src/modes/interactive/components/shell-sidebar.ts
@@ -3,6 +3,7 @@ import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/p
 import type { AgentSession } from "../../../core/agent-session.js";
 import type { ExtensionSidebarSection } from "../../../core/extensions/types.js";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.js";
+import { COPILOT_MULTIPLIERS } from "../../../utils/copilot-model-policies.js";
 import { type ThemeColor, theme } from "../theme/theme.js";
 import {
 	formatContextSummary,
@@ -118,6 +119,20 @@ function formatWorkspaceName(cwd: string): string {
 	return parts.at(-1) ?? cwd;
 }
 
+function getModelProviderBadge(model: AgentSession["model"]): string {
+	if (!model) {
+		return theme.fg("muted", "unresolved");
+	}
+
+	if (model.provider !== "github-copilot") {
+		return theme.fg("dim", `(${model.provider})`);
+	}
+
+	const multiplier = COPILOT_MULTIPLIERS[model.id];
+	const multiplierBadge = multiplier !== undefined ? ` · x${multiplier}` : "";
+	return theme.fg("dim", `(${model.provider}${multiplierBadge})`);
+}
+
 export class ShellSidebarComponent implements Component {
 	private height = 0;
 	private resourceSections: SidebarDisplaySection[] = [];
@@ -149,6 +164,7 @@ export class ShellSidebarComponent implements Component {
 		const contentWidth = Math.max(1, width - 2);
 		const border = theme.fg("muted", "│");
 		const blank = `${border} ${" ".repeat(contentWidth)}`;
+		const borderlessBlank = " ".repeat(width);
 		const divider = `${border} ${theme.fg("borderMuted", "─".repeat(contentWidth))}`;
 		const wrapLine = (text: string): string[] => {
 			const wrapped = wrapTextWithAnsi(text, contentWidth);
@@ -238,9 +254,7 @@ export class ShellSidebarComponent implements Component {
 
 		const model = this.session.model;
 		if (model) {
-			headerGroup.push(
-				...labeledSection("Model", `${theme.fg("text", model.id)} ${theme.fg("dim", `(${model.provider})`)}`),
-			);
+			headerGroup.push(...labeledSection("Model", `${theme.fg("text", model.id)} ${getModelProviderBadge(model)}`));
 		} else {
 			headerGroup.push(...labeledSection("Model", theme.fg("muted", "unresolved")));
 		}
@@ -293,7 +307,11 @@ export class ShellSidebarComponent implements Component {
 		} else if (contextUsage) {
 			contextGroup.push(...compactSection("Context", theme.fg("muted", formatContextSummary(contextUsage))));
 		}
-		contextGroup.push(...renderExtensionSections(contextSections));
+		const renderedContextSections = renderExtensionSections(contextSections);
+		if (contextGroup.length > 0 && renderedContextSections.length > 0) {
+			contextGroup.push(blank);
+		}
+		contextGroup.push(...renderedContextSections);
 		if (contextGroup.length > 0) {
 			topGroups.push(contextGroup);
 		}
@@ -331,12 +349,35 @@ export class ShellSidebarComponent implements Component {
 
 		const topLines = joinGroups(topGroups);
 		const bottomLines = joinGroups(bottomGroups);
-
 		const maxBottomHeight = Math.max(0, this.height - topLines.length);
 		const visibleBottomLines = bottomLines.slice(Math.max(0, bottomLines.length - maxBottomHeight));
-		const spacerHeight = Math.max(0, this.height - topLines.length - visibleBottomLines.length);
+		let spacerHeight = Math.max(0, this.height - topLines.length - visibleBottomLines.length);
+		const footerSectionPrefix: string[] = [];
+		const footerPadding: string[] = [];
 
-		const lines = [...topLines, ...Array.from({ length: spacerHeight }, () => blank), ...visibleBottomLines];
+		if (bottomLines.length > 0 && spacerHeight > 0) {
+			footerPadding.push(borderlessBlank);
+			spacerHeight -= 1;
+		}
+		if (topLines.length > 0 && bottomLines.length > 0 && spacerHeight > 0) {
+			footerSectionPrefix.push(divider);
+			spacerHeight -= 1;
+			if (spacerHeight > 0) {
+				footerSectionPrefix.push(blank);
+				spacerHeight -= 1;
+			}
+		} else if (bottomLines.length > 0 && spacerHeight > 0) {
+			footerSectionPrefix.push(blank);
+			spacerHeight -= 1;
+		}
+
+		const lines = [
+			...topLines,
+			...Array.from({ length: spacerHeight }, () => blank),
+			...footerSectionPrefix,
+			...visibleBottomLines,
+			...footerPadding,
+		];
 		return lines.slice(0, this.height);
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/skill-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/skill-selector.ts
@@ -1,0 +1,218 @@
+import {
+	Container,
+	type Focusable,
+	fuzzyFilter,
+	getKeybindings,
+	Input,
+	Spacer,
+	Text,
+	TruncatedText,
+} from "@mariozechner/pi-tui";
+import type { Skill } from "../../../core/skills.js";
+import { theme } from "../theme/theme.js";
+import { DynamicBorder } from "./dynamic-border.js";
+
+interface SkillItem {
+	name: string;
+	description: string;
+	enabled: boolean;
+}
+
+export class SkillSelectorComponent extends Container implements Focusable {
+	private allItems: SkillItem[];
+	private filteredItems: SkillItem[] = [];
+	private selectedIndex = 0;
+	private searchInput: Input;
+	private listContainer: Container;
+	private footerText: Text;
+	private detailText: Text;
+	private maxVisible = 8;
+
+	private _focused = false;
+	get focused(): boolean {
+		return this._focused;
+	}
+	set focused(value: boolean) {
+		this._focused = value;
+		this.searchInput.focused = value;
+	}
+
+	private onConfirmCallback: (disabledNames: string[]) => void;
+	private onCancelCallback: () => void;
+
+	constructor(
+		allSkills: Skill[],
+		disabledNames: string[],
+		onConfirm: (disabledNames: string[]) => void,
+		onCancel: () => void,
+		initialSearch?: string,
+	) {
+		super();
+
+		this.onConfirmCallback = onConfirm;
+		this.onCancelCallback = onCancel;
+
+		const disabledSet = new Set(disabledNames);
+		this.allItems = allSkills.map((s) => ({
+			name: s.name,
+			description: s.description,
+			enabled: !disabledSet.has(s.name),
+		}));
+
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("accent", theme.bold("Skill Selector")), 0, 0));
+		this.addChild(
+			new Text(theme.fg("muted", "Enter = toggle · Ctrl+A = all on · Ctrl+X = all off · Esc = done"), 0, 0),
+		);
+		this.addChild(new Spacer(1));
+
+		this.searchInput = new Input();
+		if (initialSearch) {
+			this.searchInput.setValue(initialSearch);
+		}
+		this.addChild(this.searchInput);
+		this.addChild(new Spacer(1));
+
+		this.listContainer = new Container();
+		this.addChild(this.listContainer);
+
+		this.addChild(new Spacer(1));
+		this.detailText = new Text("", 0, 0);
+		this.addChild(this.detailText);
+
+		this.addChild(new Spacer(1));
+		this.footerText = new Text(this.getFooterText(), 0, 0);
+		this.addChild(this.footerText);
+		this.addChild(new DynamicBorder());
+
+		this.refresh();
+	}
+
+	private getFooterText(): string {
+		const enabledCount = this.allItems.filter((i) => i.enabled).length;
+		const total = this.allItems.length;
+		return theme.fg("dim", `  ${enabledCount}/${total} active`);
+	}
+
+	private refresh(): void {
+		const query = this.searchInput.getValue();
+		const items = this.allItems;
+		this.filteredItems = query ? fuzzyFilter(items, query, (i) => `${i.name} ${i.description}`) : items;
+		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredItems.length - 1));
+		this.updateList();
+		this.footerText.setText(this.getFooterText());
+		this.updateDetail();
+	}
+
+	private updateDetail(): void {
+		const item = this.filteredItems[this.selectedIndex];
+		if (item) {
+			this.detailText.setText(theme.fg("muted", `  ${item.description}`));
+		} else {
+			this.detailText.setText("");
+		}
+	}
+
+	private updateList(): void {
+		this.listContainer.clear();
+
+		if (this.filteredItems.length === 0) {
+			this.listContainer.addChild(new Text(theme.fg("muted", "  No matching skills"), 0, 0));
+			return;
+		}
+
+		const startIndex = Math.max(
+			0,
+			Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.filteredItems.length - this.maxVisible),
+		);
+		const endIndex = Math.min(startIndex + this.maxVisible, this.filteredItems.length);
+
+		for (let i = startIndex; i < endIndex; i++) {
+			const item = this.filteredItems[i]!;
+			const isSelected = i === this.selectedIndex;
+			const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
+			const checkbox = item.enabled ? theme.fg("success", "[x]") : theme.fg("dim", "[ ]");
+			const nameText = isSelected ? theme.fg("accent", item.name) : item.name;
+			const descSnippet = theme.fg("dim", ` — ${item.description}`);
+			this.listContainer.addChild(new TruncatedText(`${prefix}${checkbox} ${nameText}${descSnippet}`, 0, 0));
+		}
+
+		if (startIndex > 0 || endIndex < this.filteredItems.length) {
+			this.listContainer.addChild(
+				new Text(theme.fg("muted", `  (${this.selectedIndex + 1}/${this.filteredItems.length})`), 0, 0),
+			);
+		}
+	}
+
+	private getDisabledNames(): string[] {
+		return this.allItems.filter((i) => !i.enabled).map((i) => i.name);
+	}
+
+	handleInput(data: string): void {
+		const kb = getKeybindings();
+
+		if (kb.matches(data, "tui.select.up")) {
+			if (this.filteredItems.length === 0) return;
+			this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;
+			this.updateList();
+			this.updateDetail();
+			return;
+		}
+
+		if (kb.matches(data, "tui.select.down")) {
+			if (this.filteredItems.length === 0) return;
+			this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
+			this.updateList();
+			this.updateDetail();
+			return;
+		}
+
+		if (kb.matches(data, "tui.select.confirm")) {
+			const item = this.filteredItems[this.selectedIndex];
+			if (item) {
+				const allItem = this.allItems.find((i) => i.name === item.name);
+				if (allItem) {
+					allItem.enabled = !allItem.enabled;
+					this.onConfirmCallback(this.getDisabledNames());
+					this.refresh();
+				}
+			}
+			return;
+		}
+
+		if (kb.matches(data, "tui.select.cancel")) {
+			this.onCancelCallback();
+			return;
+		}
+
+		if (kb.matches(data, "app.skills.enableAll")) {
+			const query = this.searchInput.getValue();
+			const targets = query ? this.filteredItems.map((i) => i.name) : null;
+			for (const item of this.allItems) {
+				if (targets === null || targets.includes(item.name)) {
+					item.enabled = true;
+				}
+			}
+			this.onConfirmCallback(this.getDisabledNames());
+			this.refresh();
+			return;
+		}
+
+		if (kb.matches(data, "app.skills.disableAll")) {
+			const query = this.searchInput.getValue();
+			const targets = query ? this.filteredItems.map((i) => i.name) : null;
+			for (const item of this.allItems) {
+				if (targets === null || targets.includes(item.name)) {
+					item.enabled = false;
+				}
+			}
+			this.onConfirmCallback(this.getDisabledNames());
+			this.refresh();
+			return;
+		}
+
+		this.searchInput.handleInput(data);
+		this.refresh();
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -63,9 +63,6 @@ export class ThinkingSelectorComponent extends Container {
 		};
 
 		this.addChild(this.selectList);
-
-		// Add bottom border
-		this.addChild(new DynamicBorder());
 	}
 
 	getSelectList(): SelectList {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -42,6 +42,7 @@ import {
 	visibleWidth,
 } from "@mariozechner/pi-tui";
 import { spawn, spawnSync } from "child_process";
+import { isValidThinkingLevel } from "../../cli/args.js";
 import {
 	APP_NAME,
 	APP_SYMBOL,
@@ -107,6 +108,7 @@ import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { ShellDockComponent } from "./components/shell-dock.js";
 import { ShellSidebarComponent } from "./components/shell-sidebar.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
+import { ThinkingSelectorComponent } from "./components/thinking-selector.js";
 import { ToolExecutionComponent } from "./components/tool-execution.js";
 import { TreeSelectorComponent } from "./components/tree-selector.js";
 import { UserMessageComponent } from "./components/user-message.js";
@@ -2821,6 +2823,12 @@ export class InteractiveMode {
 				await this.handleModelCommand(searchTerm);
 				return;
 			}
+			if (text === "/thinking" || text.startsWith("/thinking ")) {
+				const level = text.startsWith("/thinking ") ? text.slice(10).trim() : undefined;
+				this.editor.setText("");
+				this.handleThinkingCommand(level);
+				return;
+			}
 			if (text === "/export" || text.startsWith("/export ")) {
 				await this.handleExportCommand(text);
 				this.editor.setText("");
@@ -4222,6 +4230,56 @@ export class InteractiveMode {
 				},
 			);
 			return { component: selector, focus: selector.getSettingsList() };
+		});
+	}
+
+	private handleThinkingCommand(levelText?: string): void {
+		if (!levelText) {
+			this.showThinkingSelector();
+			return;
+		}
+
+		if (!isValidThinkingLevel(levelText)) {
+			this.showError(`Invalid thinking level "${levelText}". Valid values: off, minimal, low, medium, high, xhigh`);
+			return;
+		}
+
+		const availableLevels = this.session.getAvailableThinkingLevels();
+		if (!availableLevels.includes(levelText)) {
+			if (availableLevels.length === 1 && availableLevels[0] === "off") {
+				this.showStatus("Current model does not support thinking");
+			} else {
+				this.showError(
+					`Thinking level "${levelText}" is not available for the current model. Available: ${availableLevels.join(", ")}`,
+				);
+			}
+			return;
+		}
+
+		this.session.setThinkingLevel(levelText);
+		this.footer.invalidate();
+		this.updateEditorBorderColor();
+		this.showStatus(`Thinking level: ${levelText}`);
+	}
+
+	private showThinkingSelector(): void {
+		this.showSelector((done) => {
+			const selector = new ThinkingSelectorComponent(
+				this.session.thinkingLevel,
+				this.session.getAvailableThinkingLevels(),
+				(level) => {
+					this.session.setThinkingLevel(level);
+					this.footer.invalidate();
+					this.updateEditorBorderColor();
+					done();
+					this.showStatus(`Thinking level: ${level}`);
+				},
+				() => {
+					done();
+					this.ui.requestRender();
+				},
+			);
+			return { component: selector, focus: selector.getSelectList() };
 		});
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -221,6 +221,7 @@ export class InteractiveMode {
 	private interactionContainer: Container;
 	private dockTransientContainer: Container;
 	private dockHintsText: Text;
+	private dockInteractionActive = false;
 	private dockHints: Container;
 	private footer: FooterComponent;
 	private footerDataProvider: FooterDataProvider;
@@ -824,8 +825,9 @@ export class InteractiveMode {
 		}
 
 		// Alternate scroll mode (?1007h) delivers scroll wheel events as Up/Down cursor keys.
-		// Route them to transcript scroll when the default editor is active and empty.
-		if (this.editor === this.defaultEditor && this.defaultEditor.getText() === "") {
+		// Route them to transcript scroll when the default editor is active, empty, and no selector
+		// overlay is shown (dock interactions capture up/down for their own navigation).
+		if (this.editor === this.defaultEditor && this.defaultEditor.getText() === "" && !this.dockInteractionActive) {
 			if (this.keybindings.matches(data, "tui.editor.cursorUp")) {
 				this.addWheelScroll("up");
 				return { consume: true };
@@ -902,6 +904,7 @@ export class InteractiveMode {
 		this.interactionContainer.clear();
 		this.interactionContainer.addChild(component);
 		this.dockComponent.setHideEditor(true);
+		this.dockInteractionActive = true;
 		this.ui.setFocus(focus);
 		this.ui.requestRender();
 	}
@@ -909,6 +912,7 @@ export class InteractiveMode {
 	private restoreComposerFocus(): void {
 		this.clearDockInteraction();
 		this.dockComponent.setHideEditor(false);
+		this.dockInteractionActive = false;
 		this.ui.setFocus(this.editor as Component);
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -207,6 +207,8 @@ export interface InteractiveModeOptions {
 	initialMessages?: string[];
 	/** Force verbose startup (overrides quietStartup setting) */
 	verbose?: boolean;
+	/** Optional note rendered in the TUI header (e.g. model scope) */
+	startupNote?: string;
 }
 
 export class InteractiveMode {
@@ -607,11 +609,6 @@ export class InteractiveMode {
 		// Load changelog (only show new entries, skip for resumed sessions)
 		this.changelogMarkdown = this.getChangelogForDisplay();
 
-		// Ensure fd and rg are available (downloads if missing, adds to PATH via getBinDir)
-		// Both are needed: fd for autocomplete, rg for grep tool and bash commands
-		const [fdPath] = await Promise.all([ensureTool("fd"), ensureTool("rg")]);
-		this.fdPath = fdPath;
-
 		// Add fixed shell layout as the single top-level child of the TUI.
 		this.ui.addChild(this.rootLayout);
 
@@ -630,9 +627,10 @@ export class InteractiveMode {
 				"dim",
 				`piper can explain its own features and look up its docs. Ask it how to use or extend piper.`,
 			);
+			const note = this.options.startupNote ? `\n${theme.fg("dim", this.options.startupNote)}` : "";
 			this.builtInHeader = new ExpandableText(
-				() => `${logo}\n${onboarding}`,
-				() => `${logo}\n${onboarding}`,
+				() => `${logo}\n${onboarding}${note}`,
+				() => `${logo}\n${onboarding}${note}`,
 				this.getStartupExpansionState(),
 				SHELL_LEFT_INSET,
 				0,
@@ -664,6 +662,12 @@ export class InteractiveMode {
 		// Start the UI before initializing extensions so session_start handlers can use interactive dialogs
 		this.ui.start();
 		this.isInitialized = true;
+
+		// Resolve fd/rg in the background — not needed until the user invokes file search or grep.
+		// Use silent mode to suppress download messages that would corrupt the TUI output.
+		Promise.all([ensureTool("fd", true), ensureTool("rg", true)]).then(([fdPath]) => {
+			this.fdPath = fdPath;
+		});
 
 		// Initialize extensions first so resources are shown before messages
 		await this.bindCurrentSessionExtensions();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -108,6 +108,7 @@ import { SettingsSelectorComponent } from "./components/settings-selector.js";
 import { ShellDockComponent } from "./components/shell-dock.js";
 import { ShellSidebarComponent } from "./components/shell-sidebar.js";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.js";
+import { SkillSelectorComponent } from "./components/skill-selector.js";
 import { ThinkingSelectorComponent } from "./components/thinking-selector.js";
 import { ToolExecutionComponent } from "./components/tool-execution.js";
 import { TreeSelectorComponent } from "./components/tree-selector.js";
@@ -1678,19 +1679,25 @@ export class InteractiveMode {
 
 			const skills = skillsResult.skills;
 			if (skills.length > 0) {
+				const disabledSkillSet = new Set(this.settingsManager.getDisabledSkills());
+				const activeSkills = skills.filter((s) => !disabledSkillSet.has(s.name));
+				const displaySkills = activeSkills.length < skills.length ? activeSkills : skills;
 				const groups = this.buildScopeGroups(
-					skills.map((skill) => ({ path: skill.filePath, sourceInfo: skill.sourceInfo })),
+					displaySkills.map((skill) => ({ path: skill.filePath, sourceInfo: skill.sourceInfo })),
 				);
 				const skillList = this.formatScopeGroups(groups, {
 					formatPath: (item) => this.formatDisplayPath(item.path),
 					formatPackagePath: (item) => this.getShortPath(item.path, item.sourceInfo),
 				});
-				const skillSummary = formatCompactSummary(skills.map((skill) => skill.name));
+				const skillSummary =
+					activeSkills.length < skills.length
+						? `${formatCompactSummary(activeSkills.map((s) => s.name))} (${activeSkills.length}/${skills.length} active)`
+						: formatCompactSummary(skills.map((skill) => skill.name));
 				if (updateSidebar) {
 					capabilitySidebarSections.push({ label: "Skills", value: skillSummary });
 				}
 				if (!updateSidebar) {
-					addLoadedSection("Skills", formatCompactList(skills.map((skill) => skill.name)), skillList);
+					addLoadedSection("Skills", formatCompactList(displaySkills.map((skill) => skill.name)), skillList);
 				}
 			}
 
@@ -2759,6 +2766,7 @@ export class InteractiveMode {
 		this.ui.onDebug = () => this.handleDebugCommand();
 		this.ui.addInputListener((data) => this.handleTranscriptInput(data));
 		this.defaultEditor.onAction("app.model.select", () => this.showModelSelector());
+		this.defaultEditor.onAction("app.skills.select", () => this.showSkillSelector());
 		this.defaultEditor.onAction("app.tools.expand", () => this.toggleToolOutputExpansion());
 		this.defaultEditor.onAction("app.thinking.toggle", () => this.toggleThinkingBlockVisibility());
 		this.defaultEditor.onAction("app.editor.external", () => this.openExternalEditor());
@@ -2826,6 +2834,12 @@ export class InteractiveMode {
 				const searchTerm = text.startsWith("/model ") ? text.slice(7).trim() : undefined;
 				this.editor.setText("");
 				await this.handleModelCommand(searchTerm);
+				return;
+			}
+			if (text === "/skills" || text.startsWith("/skills ")) {
+				const searchTerm = text.startsWith("/skills ") ? text.slice(8).trim() : undefined;
+				this.editor.setText("");
+				this.showSkillSelector(searchTerm);
 				return;
 			}
 			if (text === "/thinking" || text.startsWith("/thinking ")) {
@@ -4393,6 +4407,33 @@ export class InteractiveMode {
 					this.ui.requestRender();
 				},
 				initialSearchInput,
+			);
+			return { component: selector, focus: selector };
+		});
+	}
+
+	private showSkillSelector(initialSearch?: string): void {
+		const allSkills = this.session.resourceLoader.getSkills().skills;
+		if (allSkills.length === 0) {
+			this.showStatus("No skills loaded");
+			return;
+		}
+		this.showSelector((done) => {
+			const disabled = this.settingsManager.getDisabledSkills();
+			const selector = new SkillSelectorComponent(
+				allSkills,
+				disabled,
+				(newDisabled) => {
+					this.settingsManager.setProjectDisabledSkills(newDisabled);
+					this.session.rebuildSystemPrompt();
+					this.showLoadedResources({ force: false });
+					this.showStatus(`Skills: ${allSkills.length - newDisabled.length}/${allSkills.length} active`);
+				},
+				() => {
+					done();
+					this.ui.requestRender();
+				},
+				initialSearch,
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -129,6 +129,7 @@ import {
 	type ThemeColor,
 	theme,
 } from "./theme/theme.js";
+import { UserShellSession } from "./user-shell-session.js";
 
 /** Interface for components that can be expanded/collapsed */
 interface Expandable {
@@ -280,6 +281,7 @@ export class InteractiveMode {
 
 	// Track current bash execution component
 	private bashComponent: BashExecutionComponent | undefined = undefined;
+	private userShellSession: UserShellSession | undefined = undefined;
 
 	// Track pending bash components (shown in pending area, moved to chat on submit)
 	private pendingBashComponents: BashExecutionComponent[] = [];
@@ -945,6 +947,30 @@ export class InteractiveMode {
 		} else {
 			this.ui.terminal.setTitle(`${APP_SYMBOL} - ${cwdBasename}`);
 		}
+	}
+
+	private getUserShellSession(): UserShellSession {
+		this.userShellSession ??= new UserShellSession({
+			cwd: this.sessionManager.getCwd(),
+			onCwdChange: (cwd) => this.handleUserShellCwdChange(cwd),
+		});
+		return this.userShellSession;
+	}
+
+	private handleUserShellCwdChange(cwd: string): void {
+		const resolvedCwd = path.resolve(cwd);
+		if (resolvedCwd === this.sessionManager.getCwd()) {
+			return;
+		}
+
+		this.sessionManager.setCwd(resolvedCwd);
+		this.session.settingsManager.setCwd(resolvedCwd);
+		this.session.resourceLoader.setCwd?.(resolvedCwd);
+		this.footerDataProvider.setCwd(resolvedCwd);
+		this.updateTerminalTitle();
+		this.setupAutocomplete(this.fdPath ?? undefined);
+		this.showStatus(`Workspace changed to ${resolvedCwd}. Use /reload to refresh project resources.`);
+		this.ui.requestRender();
 	}
 
 	/**
@@ -2719,6 +2745,8 @@ export class InteractiveMode {
 				this.restoreQueuedMessagesToEditor({ abort: true });
 			} else if (this.session.isBashRunning) {
 				this.session.abortBash();
+			} else if (this.userShellSession?.isCommandRunning) {
+				this.userShellSession.abortActiveCommand();
 			} else if (this.isBashMode) {
 				this.editor.setText("");
 				this.isBashMode = false;
@@ -2948,7 +2976,7 @@ export class InteractiveMode {
 				const isExcluded = text.startsWith("!!");
 				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
 				if (command) {
-					if (this.session.isBashRunning) {
+					if (this.session.isBashRunning || this.userShellSession?.isCommandRunning) {
 						this.showWarning("A bash command is already running. Press Esc to cancel it first.");
 						this.editor.setText(text);
 						return;
@@ -3587,6 +3615,8 @@ export class InteractiveMode {
 		if (this.isShuttingDown) return;
 		this.isShuttingDown = true;
 		this.unregisterSignalHandlers();
+		await this.userShellSession?.dispose();
+		this.userShellSession = undefined;
 		await this.runtimeHost.dispose();
 
 		// Wait for any pending renders to complete
@@ -5586,16 +5616,26 @@ export class InteractiveMode {
 		this.ui.requestRender();
 
 		try {
-			const result = await this.session.executeBash(
-				command,
-				(chunk) => {
-					if (this.bashComponent) {
-						this.bashComponent.appendOutput(chunk);
-						this.ui.requestRender();
-					}
-				},
-				{ excludeFromContext, operations: eventResult?.operations },
-			);
+			const result = eventResult?.operations
+				? await this.session.executeBash(
+						command,
+						(chunk) => {
+							if (this.bashComponent) {
+								this.bashComponent.appendOutput(chunk);
+								this.ui.requestRender();
+							}
+						},
+						{
+							excludeFromContext,
+							operations: eventResult.operations,
+						},
+					)
+				: await this.getUserShellSession().execute(command, (chunk) => {
+						if (this.bashComponent) {
+							this.bashComponent.appendOutput(chunk);
+							this.ui.requestRender();
+						}
+					});
 
 			if (this.bashComponent) {
 				this.bashComponent.setComplete(
@@ -5604,6 +5644,9 @@ export class InteractiveMode {
 					result.truncated ? ({ truncated: true, content: result.output } as TruncationResult) : undefined,
 					result.fullOutputPath,
 				);
+			}
+			if (!eventResult?.operations) {
+				this.session.recordBashResult(command, result, { excludeFromContext });
 			}
 		} catch (error) {
 			if (this.bashComponent) {
@@ -5640,6 +5683,8 @@ export class InteractiveMode {
 
 	stop(): void {
 		this.unregisterSignalHandlers();
+		void this.userShellSession?.dispose();
+		this.userShellSession = undefined;
 		if (this.loadingAnimation) {
 			this.loadingAnimation.stop();
 			this.loadingAnimation = undefined;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -129,7 +129,6 @@ import {
 	type ThemeColor,
 	theme,
 } from "./theme/theme.js";
-import { UserShellSession } from "./user-shell-session.js";
 
 /** Interface for components that can be expanded/collapsed */
 interface Expandable {
@@ -281,7 +280,6 @@ export class InteractiveMode {
 
 	// Track current bash execution component
 	private bashComponent: BashExecutionComponent | undefined = undefined;
-	private userShellSession: UserShellSession | undefined = undefined;
 
 	// Track pending bash components (shown in pending area, moved to chat on submit)
 	private pendingBashComponents: BashExecutionComponent[] = [];
@@ -947,30 +945,6 @@ export class InteractiveMode {
 		} else {
 			this.ui.terminal.setTitle(`${APP_SYMBOL} - ${cwdBasename}`);
 		}
-	}
-
-	private getUserShellSession(): UserShellSession {
-		this.userShellSession ??= new UserShellSession({
-			cwd: this.sessionManager.getCwd(),
-			onCwdChange: (cwd) => this.handleUserShellCwdChange(cwd),
-		});
-		return this.userShellSession;
-	}
-
-	private handleUserShellCwdChange(cwd: string): void {
-		const resolvedCwd = path.resolve(cwd);
-		if (resolvedCwd === this.sessionManager.getCwd()) {
-			return;
-		}
-
-		this.sessionManager.setCwd(resolvedCwd);
-		this.session.settingsManager.setCwd(resolvedCwd);
-		this.session.resourceLoader.setCwd?.(resolvedCwd);
-		this.footerDataProvider.setCwd(resolvedCwd);
-		this.updateTerminalTitle();
-		this.setupAutocomplete(this.fdPath ?? undefined);
-		this.showStatus(`Workspace changed to ${resolvedCwd}. Use /reload to refresh project resources.`);
-		this.ui.requestRender();
 	}
 
 	/**
@@ -2745,8 +2719,6 @@ export class InteractiveMode {
 				this.restoreQueuedMessagesToEditor({ abort: true });
 			} else if (this.session.isBashRunning) {
 				this.session.abortBash();
-			} else if (this.userShellSession?.isCommandRunning) {
-				this.userShellSession.abortActiveCommand();
 			} else if (this.isBashMode) {
 				this.editor.setText("");
 				this.isBashMode = false;
@@ -2976,7 +2948,7 @@ export class InteractiveMode {
 				const isExcluded = text.startsWith("!!");
 				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
 				if (command) {
-					if (this.session.isBashRunning || this.userShellSession?.isCommandRunning) {
+					if (this.session.isBashRunning) {
 						this.showWarning("A bash command is already running. Press Esc to cancel it first.");
 						this.editor.setText(text);
 						return;
@@ -3615,8 +3587,6 @@ export class InteractiveMode {
 		if (this.isShuttingDown) return;
 		this.isShuttingDown = true;
 		this.unregisterSignalHandlers();
-		await this.userShellSession?.dispose();
-		this.userShellSession = undefined;
 		await this.runtimeHost.dispose();
 
 		// Wait for any pending renders to complete
@@ -5616,26 +5586,16 @@ export class InteractiveMode {
 		this.ui.requestRender();
 
 		try {
-			const result = eventResult?.operations
-				? await this.session.executeBash(
-						command,
-						(chunk) => {
-							if (this.bashComponent) {
-								this.bashComponent.appendOutput(chunk);
-								this.ui.requestRender();
-							}
-						},
-						{
-							excludeFromContext,
-							operations: eventResult.operations,
-						},
-					)
-				: await this.getUserShellSession().execute(command, (chunk) => {
-						if (this.bashComponent) {
-							this.bashComponent.appendOutput(chunk);
-							this.ui.requestRender();
-						}
-					});
+			const result = await this.session.executeBash(
+				command,
+				(chunk) => {
+					if (this.bashComponent) {
+						this.bashComponent.appendOutput(chunk);
+						this.ui.requestRender();
+					}
+				},
+				{ excludeFromContext, operations: eventResult?.operations, userShell: !eventResult?.operations },
+			);
 
 			if (this.bashComponent) {
 				this.bashComponent.setComplete(
@@ -5645,9 +5605,7 @@ export class InteractiveMode {
 					result.fullOutputPath,
 				);
 			}
-			if (!eventResult?.operations) {
-				this.session.recordBashResult(command, result, { excludeFromContext });
-			}
+			this.session.recordBashResult(command, result, { excludeFromContext });
 		} catch (error) {
 			if (this.bashComponent) {
 				this.bashComponent.setComplete(undefined, false);
@@ -5683,8 +5641,6 @@ export class InteractiveMode {
 
 	stop(): void {
 		this.unregisterSignalHandlers();
-		void this.userShellSession?.dispose();
-		this.userShellSession = undefined;
 		if (this.loadingAnimation) {
 			this.loadingAnimation.stop();
 			this.loadingAnimation = undefined;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -169,6 +169,8 @@ type SidebarDisplaySection = ExtensionSidebarSection & { order?: number };
 
 const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
 	"Anthropic subscription auth is active. Third-party usage now draws from extra usage and is billed per token, not your Claude plan limits. Manage extra usage at https://claude.ai/settings/usage.";
+const DEFAULT_COMPOSER_PLACEHOLDER = "Ask piper, add @files, or use /commands";
+const SHELL_LEFT_INSET = 1;
 
 function isAnthropicSubscriptionAuthKey(apiKey: string | undefined): boolean {
 	return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
@@ -381,7 +383,7 @@ export class InteractiveMode {
 		this.widgetContainerBelow = new Container();
 		this.interactionContainer = new Container();
 		this.dockTransientContainer = new Container();
-		this.dockHintsText = new Text("", 0, 0);
+		this.dockHintsText = new Text("", SHELL_LEFT_INSET, 0);
 		this.dockHints = new Container();
 		this.dockHints.addChild(new Spacer(1));
 		this.dockHints.addChild(this.dockHintsText);
@@ -398,6 +400,8 @@ export class InteractiveMode {
 		this.defaultEditor = new CustomEditor(this.ui, getEditorTheme(), this.keybindings, {
 			paddingX: editorPaddingX,
 			autocompleteMaxVisible,
+			placeholder: DEFAULT_COMPOSER_PLACEHOLDER,
+			placeholderStyle: (text: string) => theme.fg("dim", text),
 		});
 		this.editor = this.defaultEditor;
 		this.editorContainer = new Container();
@@ -628,7 +632,7 @@ export class InteractiveMode {
 				() => `${logo}\n${onboarding}`,
 				() => `${logo}\n${onboarding}`,
 				this.getStartupExpansionState(),
-				1,
+				SHELL_LEFT_INSET,
 				0,
 			);
 
@@ -1596,7 +1600,7 @@ export class InteractiveMode {
 				() => `${sectionHeader(name, color)}\n${collapsedBody}`,
 				() => `${sectionHeader(name, color)}\n${expandedBody}`,
 				this.getStartupExpansionState(),
-				0,
+				SHELL_LEFT_INSET,
 				0,
 			);
 			this.chatContainer.addChild(section);
@@ -1779,9 +1783,13 @@ export class InteractiveMode {
 			if (skillDiagnostics.length > 0) {
 				if (showFullDiagnostics) {
 					const warningLines = this.formatDiagnostics(skillDiagnostics, sourceInfos);
-					this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Skill issues]")}\n${warningLines}`, 0, 0));
+					this.chatContainer.addChild(
+						new Text(`${theme.fg("warning", "[Skill issues]")}\n${warningLines}`, SHELL_LEFT_INSET, 0),
+					);
 				} else {
-					this.chatContainer.addChild(new Text(this.formatDiagnosticsCompact("Skills", skillDiagnostics), 0, 0));
+					this.chatContainer.addChild(
+						new Text(this.formatDiagnosticsCompact("Skills", skillDiagnostics), SHELL_LEFT_INSET, 0),
+					);
 				}
 			}
 
@@ -1790,10 +1798,12 @@ export class InteractiveMode {
 				if (showFullDiagnostics) {
 					const warningLines = this.formatDiagnostics(promptDiagnostics, sourceInfos);
 					this.chatContainer.addChild(
-						new Text(`${theme.fg("warning", "[Prompt issues]")}\n${warningLines}`, 0, 0),
+						new Text(`${theme.fg("warning", "[Prompt issues]")}\n${warningLines}`, SHELL_LEFT_INSET, 0),
 					);
 				} else {
-					this.chatContainer.addChild(new Text(this.formatDiagnosticsCompact("Prompts", promptDiagnostics), 0, 0));
+					this.chatContainer.addChild(
+						new Text(this.formatDiagnosticsCompact("Prompts", promptDiagnostics), SHELL_LEFT_INSET, 0),
+					);
 				}
 			}
 
@@ -1816,11 +1826,11 @@ export class InteractiveMode {
 				if (showFullDiagnostics) {
 					const warningLines = this.formatDiagnostics(extensionDiagnostics, sourceInfos);
 					this.chatContainer.addChild(
-						new Text(`${theme.fg("warning", "[Extension issues]")}\n${warningLines}`, 0, 0),
+						new Text(`${theme.fg("warning", "[Extension issues]")}\n${warningLines}`, SHELL_LEFT_INSET, 0),
 					);
 				} else {
 					this.chatContainer.addChild(
-						new Text(this.formatDiagnosticsCompact("Extensions", extensionDiagnostics), 0, 0),
+						new Text(this.formatDiagnosticsCompact("Extensions", extensionDiagnostics), SHELL_LEFT_INSET, 0),
 					);
 				}
 			}
@@ -1829,9 +1839,13 @@ export class InteractiveMode {
 			if (themeDiagnostics.length > 0) {
 				if (showFullDiagnostics) {
 					const warningLines = this.formatDiagnostics(themeDiagnostics, sourceInfos);
-					this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Theme issues]")}\n${warningLines}`, 0, 0));
+					this.chatContainer.addChild(
+						new Text(`${theme.fg("warning", "[Theme issues]")}\n${warningLines}`, SHELL_LEFT_INSET, 0),
+					);
 				} else {
-					this.chatContainer.addChild(new Text(this.formatDiagnosticsCompact("Themes", themeDiagnostics), 0, 0));
+					this.chatContainer.addChild(
+						new Text(this.formatDiagnosticsCompact("Themes", themeDiagnostics), SHELL_LEFT_INSET, 0),
+					);
 				}
 			}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -649,6 +649,7 @@ export class InteractiveMode {
 		}
 
 		this.transcriptContainer.addChild(this.chatContainer);
+		this.transcriptContainer.addChild(new Spacer(1));
 		this.dockTransientContainer.addChild(this.pendingMessagesContainer);
 		this.dockTransientContainer.addChild(this.statusContainer);
 		this.renderWidgets(); // Initialize with default spacer

--- a/packages/coding-agent/src/modes/interactive/user-shell-session.ts
+++ b/packages/coding-agent/src/modes/interactive/user-shell-session.ts
@@ -1,0 +1,420 @@
+import { createWriteStream, promises as fs, type WriteStream } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import * as nodePty from "node-pty";
+import stripAnsi from "strip-ansi";
+import type { BashResult } from "../../core/bash-executor.js";
+import { DEFAULT_MAX_BYTES, truncateTail } from "../../core/tools/truncate.js";
+import { getShellConfig, getShellEnv, sanitizeBinaryOutput } from "../../utils/shell.js";
+
+const OUTPUT_BUFFER_BYTES = DEFAULT_MAX_BYTES * 2;
+const START_MARKER_PREFIX = "__PIPER_USER_SHELL_START__";
+const END_MARKER_PREFIX = "__PIPER_USER_SHELL_END__";
+const CANCEL_EXIT_CODE = 130;
+
+type ShellFamily = "posix" | "fish";
+
+type ActiveCommand = {
+	id: string;
+	started: boolean;
+	abortRequested: boolean;
+	scriptPath: string;
+	parseBuffer: string;
+	outputChunks: string[];
+	outputBytes: number;
+	totalBytes: number;
+	tempFilePath?: string;
+	tempFileStream?: WriteStream;
+	onChunk?: (chunk: string) => void;
+	resolve: (result: BashResult) => void;
+	reject: (error: Error) => void;
+};
+
+function getShellFamily(shellPath: string): ShellFamily {
+	const shellName = basename(shellPath).toLowerCase();
+	if (shellName === "fish") {
+		return "fish";
+	}
+	return "posix";
+}
+
+function getStartMarker(id: string): string {
+	return `${START_MARKER_PREFIX}${id}__`;
+}
+
+function getEndMarkerPrefix(id: string): string {
+	return `${END_MARKER_PREFIX}${id}__`;
+}
+
+function stripTrailingLineBreak(text: string): string {
+	return text.replace(/\r?\n$/, "");
+}
+
+function findLineEnd(text: string, fromIndex: number): number {
+	const lineFeedIndex = text.indexOf("\n", fromIndex);
+	if (lineFeedIndex === -1) {
+		return -1;
+	}
+	return lineFeedIndex + 1;
+}
+
+function quoteShellPath(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function createUserShellScript(command: string, id: string, family: ShellFamily): string {
+	const startMarker = getStartMarker(id);
+	const endMarker = getEndMarkerPrefix(id);
+
+	if (family === "fish") {
+		return [
+			`printf '%s\\n' '${startMarker}'`,
+			command,
+			"set -l __piper_exit $status",
+			"set -l __piper_cwd (pwd)",
+			`printf '%s\\t%s\\t%s\\n' '${endMarker}' "$__piper_exit" "$__piper_cwd"`,
+			"",
+		].join("\n");
+	}
+
+	return [
+		"__piper_finish() {",
+		'\t__piper_exit="$1"',
+		"\t__piper_cwd=$(pwd)",
+		`\tprintf '%s\\t%s\\t%s\\n' '${endMarker}' "$__piper_exit" "$__piper_cwd"`,
+		"\ttrap - INT",
+		"}",
+		"__piper_interrupted=''",
+		`trap '__piper_interrupted=${CANCEL_EXIT_CODE}' INT`,
+		`printf '%s\\n' '${startMarker}'`,
+		command,
+		"__piper_exit=$?",
+		'if [ -n "$__piper_interrupted" ]; then',
+		'\t__piper_exit="$__piper_interrupted"',
+		"fi",
+		'__piper_finish "$__piper_exit"',
+		"",
+	].join("\n");
+}
+
+export function parseUserShellEndLine(
+	line: string,
+	id: string,
+): { exitCode: number | undefined; cwd: string } | undefined {
+	const prefix = getEndMarkerPrefix(id);
+	if (!line.startsWith(prefix)) {
+		return undefined;
+	}
+
+	const [marker, exitCodeText = "", cwd = ""] = line.split("\t", 3);
+	if (marker !== prefix) {
+		return undefined;
+	}
+
+	const parsedExitCode = Number.parseInt(exitCodeText, 10);
+	return {
+		exitCode: Number.isFinite(parsedExitCode) ? parsedExitCode : undefined,
+		cwd,
+	};
+}
+
+export class UserShellSession {
+	private cwd: string;
+	private tempDir: string | undefined;
+	private shell: nodePty.IPty | undefined;
+	private shellExitDisposable: nodePty.IDisposable | undefined;
+	private shellDataDisposable: nodePty.IDisposable | undefined;
+	private activeCommand: ActiveCommand | undefined;
+	private executionQueue: Promise<unknown> = Promise.resolve();
+	private disposed = false;
+	private readonly shellPath: string;
+	private readonly shellFamily: ShellFamily;
+	private readonly onCwdChange?: (cwd: string) => void;
+
+	constructor(options: { cwd: string; onCwdChange?: (cwd: string) => void }) {
+		const { shell } = getShellConfig("user");
+		this.cwd = resolve(options.cwd);
+		this.shellPath = shell;
+		this.shellFamily = getShellFamily(shell);
+		this.onCwdChange = options.onCwdChange;
+	}
+
+	get isCommandRunning(): boolean {
+		return this.activeCommand !== undefined;
+	}
+
+	async execute(command: string, onChunk?: (chunk: string) => void): Promise<BashResult> {
+		const run = this.executionQueue.then(() => this.executeQueued(command, onChunk));
+		this.executionQueue = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		return run;
+	}
+
+	abortActiveCommand(): void {
+		if (!this.activeCommand || !this.shell) {
+			return;
+		}
+
+		this.activeCommand.abortRequested = true;
+		this.shell.write("\u0003");
+	}
+
+	async dispose(): Promise<void> {
+		this.disposed = true;
+		this.shellDataDisposable?.dispose();
+		this.shellDataDisposable = undefined;
+		this.shellExitDisposable?.dispose();
+		this.shellExitDisposable = undefined;
+		this.shell?.kill();
+		this.shell = undefined;
+		this.activeCommand = undefined;
+		if (this.tempDir) {
+			await fs.rm(this.tempDir, { recursive: true, force: true });
+			this.tempDir = undefined;
+		}
+	}
+
+	private async executeQueued(command: string, onChunk?: (chunk: string) => void): Promise<BashResult> {
+		if (this.disposed) {
+			throw new Error("User shell session has been disposed");
+		}
+
+		await this.ensureShell();
+		const id = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+		const scriptPath = await this.writeScriptFile(id, command);
+
+		return await new Promise<BashResult>((resolve, reject) => {
+			if (!this.shell) {
+				reject(new Error("Shell exited before command could be sent"));
+				return;
+			}
+
+			this.activeCommand = {
+				id,
+				started: false,
+				abortRequested: false,
+				scriptPath,
+				parseBuffer: "",
+				outputChunks: [],
+				outputBytes: 0,
+				totalBytes: 0,
+				onChunk,
+				resolve,
+				reject,
+			};
+
+			try {
+				this.shell.write(`${this.getSourceCommand(scriptPath)}\r`);
+			} catch (err) {
+				this.activeCommand = undefined;
+				reject(new Error(`Failed to send command to shell: ${err instanceof Error ? err.message : String(err)}`));
+			}
+		});
+	}
+
+	private async ensureShell(): Promise<void> {
+		if (this.shell) {
+			return;
+		}
+
+		this.tempDir ??= await fs.mkdtemp(join(tmpdir(), "piper-user-shell-"));
+		this.shell = nodePty.spawn(this.shellPath, ["-i"], {
+			name: process.env.TERM || "xterm-256color",
+			cols: process.stdout.columns || 80,
+			rows: process.stdout.rows || 24,
+			cwd: this.cwd,
+			env: getShellEnv(),
+		});
+
+		this.shellDataDisposable = this.shell.onData((data) => {
+			this.handleShellData(data);
+		});
+		this.shellExitDisposable = this.shell.onExit(({ exitCode }) => {
+			const activeCommand = this.activeCommand;
+			this.shellDataDisposable?.dispose();
+			this.shellDataDisposable = undefined;
+			this.shellExitDisposable?.dispose();
+			this.shellExitDisposable = undefined;
+			this.shell = undefined;
+			if (!activeCommand) {
+				return;
+			}
+			void this.completeActiveCommand(exitCode, activeCommand.abortRequested);
+		});
+	}
+
+	private async writeScriptFile(id: string, command: string): Promise<string> {
+		this.tempDir ??= await fs.mkdtemp(join(tmpdir(), "piper-user-shell-"));
+		const extension = this.shellFamily === "fish" ? "fish" : "sh";
+		const scriptPath = join(this.tempDir, `command-${id}.${extension}`);
+		await fs.writeFile(scriptPath, createUserShellScript(command, id, this.shellFamily), "utf8");
+		return scriptPath;
+	}
+
+	private getSourceCommand(scriptPath: string): string {
+		const quotedPath = quoteShellPath(scriptPath);
+		if (this.shellFamily === "fish") {
+			return `source ${quotedPath}`;
+		}
+		return `. ${quotedPath}`;
+	}
+
+	private handleShellData(data: string): void {
+		const activeCommand = this.activeCommand;
+		if (!activeCommand) {
+			return;
+		}
+
+		activeCommand.parseBuffer += data;
+		if (!activeCommand.started) {
+			const startMarker = getStartMarker(activeCommand.id);
+			const markerIndex = activeCommand.parseBuffer.indexOf(startMarker);
+			if (markerIndex === -1) {
+				activeCommand.parseBuffer = activeCommand.parseBuffer.slice(-startMarker.length);
+				return;
+			}
+
+			const lineEnd = findLineEnd(activeCommand.parseBuffer, markerIndex + startMarker.length);
+			if (lineEnd === -1) {
+				return;
+			}
+
+			activeCommand.started = true;
+			activeCommand.parseBuffer = activeCommand.parseBuffer.slice(lineEnd);
+		}
+
+		this.flushActiveCommandOutput();
+	}
+
+	private flushActiveCommandOutput(): void {
+		const activeCommand = this.activeCommand;
+		if (!activeCommand || !activeCommand.started) {
+			return;
+		}
+
+		const endMarkerPrefix = getEndMarkerPrefix(activeCommand.id);
+		while (true) {
+			const markerIndex = activeCommand.parseBuffer.indexOf(endMarkerPrefix);
+			if (markerIndex === -1) {
+				const tailSize = endMarkerPrefix.length + 4096;
+				const emitLength = Math.max(0, activeCommand.parseBuffer.length - tailSize);
+				if (emitLength > 0) {
+					this.appendCommandOutput(activeCommand, activeCommand.parseBuffer.slice(0, emitLength));
+					activeCommand.parseBuffer = activeCommand.parseBuffer.slice(emitLength);
+				}
+				return;
+			}
+
+			if (markerIndex > 0) {
+				this.appendCommandOutput(activeCommand, activeCommand.parseBuffer.slice(0, markerIndex));
+			}
+
+			const lineEnd = findLineEnd(activeCommand.parseBuffer, markerIndex + endMarkerPrefix.length);
+			if (lineEnd === -1) {
+				activeCommand.parseBuffer = activeCommand.parseBuffer.slice(markerIndex);
+				return;
+			}
+
+			const endLine = stripTrailingLineBreak(activeCommand.parseBuffer.slice(markerIndex, lineEnd));
+			const parsedLine = parseUserShellEndLine(endLine, activeCommand.id);
+			activeCommand.parseBuffer = activeCommand.parseBuffer.slice(lineEnd);
+			if (!parsedLine) {
+				this.appendCommandOutput(activeCommand, `${endLine}\n`);
+				continue;
+			}
+
+			void this.completeActiveCommand(parsedLine.exitCode, activeCommand.abortRequested, parsedLine.cwd);
+			return;
+		}
+	}
+
+	private appendCommandOutput(activeCommand: ActiveCommand, chunk: string): void {
+		if (!chunk) {
+			return;
+		}
+
+		const sanitizedChunk = sanitizeBinaryOutput(stripAnsi(chunk)).replace(/\r/g, "");
+		if (!sanitizedChunk) {
+			return;
+		}
+
+		activeCommand.totalBytes += sanitizedChunk.length;
+		if (activeCommand.totalBytes > DEFAULT_MAX_BYTES) {
+			this.ensureTempFile(activeCommand);
+		}
+
+		if (activeCommand.tempFileStream) {
+			activeCommand.tempFileStream.write(sanitizedChunk);
+		}
+
+		activeCommand.outputChunks.push(sanitizedChunk);
+		activeCommand.outputBytes += sanitizedChunk.length;
+		while (activeCommand.outputBytes > OUTPUT_BUFFER_BYTES && activeCommand.outputChunks.length > 1) {
+			const removed = activeCommand.outputChunks.shift() ?? "";
+			activeCommand.outputBytes -= removed.length;
+		}
+
+		activeCommand.onChunk?.(sanitizedChunk);
+	}
+
+	private ensureTempFile(activeCommand: ActiveCommand): void {
+		if (activeCommand.tempFilePath) {
+			return;
+		}
+
+		activeCommand.tempFilePath = join(this.tempDir ?? tmpdir(), `piper-user-shell-output-${activeCommand.id}.log`);
+		activeCommand.tempFileStream = createWriteStream(activeCommand.tempFilePath);
+		for (const chunk of activeCommand.outputChunks) {
+			activeCommand.tempFileStream.write(chunk);
+		}
+	}
+
+	private closeTempFileStream(activeCommand: ActiveCommand): void {
+		const tempFileStream = activeCommand.tempFileStream;
+		tempFileStream?.end();
+		activeCommand.tempFileStream = undefined;
+	}
+
+	private async completeActiveCommand(
+		exitCode: number | undefined,
+		cancelled: boolean,
+		cwd: string = this.cwd,
+	): Promise<void> {
+		const activeCommand = this.activeCommand;
+		if (!activeCommand) {
+			return;
+		}
+
+		this.activeCommand = undefined;
+		this.closeTempFileStream(activeCommand);
+
+		const fullOutput = activeCommand.outputChunks.join("");
+		const truncationResult = truncateTail(fullOutput);
+		if (truncationResult.truncated) {
+			this.ensureTempFile(activeCommand);
+			this.closeTempFileStream(activeCommand);
+		}
+
+		try {
+			await fs.unlink(activeCommand.scriptPath);
+		} catch {
+			// Best-effort cleanup only.
+		}
+
+		const resolvedCwd = resolve(cwd || this.cwd);
+		if (resolvedCwd !== this.cwd) {
+			this.cwd = resolvedCwd;
+			this.onCwdChange?.(resolvedCwd);
+		}
+
+		activeCommand.resolve({
+			output: truncationResult.truncated ? truncationResult.content : fullOutput,
+			exitCode,
+			cancelled,
+			truncated: truncationResult.truncated,
+			fullOutputPath: activeCommand.tempFilePath,
+		});
+	}
+}

--- a/packages/coding-agent/src/utils/copilot-model-policies.ts
+++ b/packages/coding-agent/src/utils/copilot-model-policies.ts
@@ -1,0 +1,93 @@
+const COPILOT_HEADERS = {
+	"User-Agent": "GitHubCopilotChat/0.35.0",
+	"Editor-Version": "vscode/1.107.0",
+	"Editor-Plugin-Version": "copilot-chat/0.35.0",
+	"Copilot-Integration-Id": "vscode-chat",
+} as const;
+
+export type CopilotModelPolicy = {
+	multiplier?: number;
+	disabled: boolean;
+};
+
+/**
+ * Static multiplier table from https://docs.github.com/en/copilot/concepts/billing/copilot-requests#model-multipliers
+ * Reflects paid-plan multipliers. Updated: 2026-04-19.
+ * Used as fallback when the live Copilot API call fails or returns no multiplier.
+ */
+export const COPILOT_MULTIPLIERS: Record<string, number> = {
+	// Claude
+	"claude-haiku-4.5": 0.33,
+	"claude-opus-4.5": 3,
+	"claude-opus-4.6": 3,
+	"claude-opus-4.7": 7.5,
+	"claude-sonnet-4": 1,
+	"claude-sonnet-4.5": 1,
+	"claude-sonnet-4.6": 1,
+	// Gemini
+	"gemini-2.5-pro": 1,
+	"gemini-3-flash-preview": 0.33,
+	"gemini-3.1-pro-preview": 1,
+	// GPT — included models (free on paid plans)
+	"gpt-4.1": 0,
+	"gpt-4o": 0,
+	"gpt-5-mini": 0,
+	// GPT — premium
+	"gpt-5.2": 1,
+	"gpt-5.2-codex": 1,
+	"gpt-5.3-codex": 1,
+	"gpt-5.4": 1,
+	"gpt-5.4-mini": 0.33,
+	// Grok
+	"grok-code-fast-1": 0.25,
+};
+
+/**
+ * Fetches model policies from the Copilot API to get premium multipliers and disabled status.
+ * Returns a map of modelId -> policy. Returns empty map on any failure.
+ */
+export async function fetchCopilotModelPolicies(
+	token: string,
+	baseUrl: string,
+): Promise<Map<string, CopilotModelPolicy>> {
+	try {
+		const response = await fetch(`${baseUrl}/models`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/json",
+				...COPILOT_HEADERS,
+			},
+			signal: AbortSignal.timeout(2500),
+		});
+		if (!response.ok) return new Map();
+
+		const raw = (await response.json()) as unknown;
+		if (!raw || typeof raw !== "object") return new Map();
+
+		const data = (raw as Record<string, unknown>).data;
+		if (!Array.isArray(data)) return new Map();
+
+		const result = new Map<string, CopilotModelPolicy>();
+		for (const entry of data) {
+			if (!entry || typeof entry !== "object") continue;
+			const m = entry as Record<string, unknown>;
+			const id = typeof m.id === "string" ? m.id : undefined;
+			if (!id) continue;
+
+			const multiplier =
+				typeof m.premium_requests_multiplier === "number" ? m.premium_requests_multiplier : undefined;
+
+			// Only filter on explicit signals: is_disabled flag or policy explicitly set to "disabled"
+			const policyState =
+				m.policy && typeof m.policy === "object"
+					? ((m.policy as Record<string, unknown>).state as string | undefined)
+					: undefined;
+			const disabled = m.is_disabled === true || policyState === "disabled";
+
+			result.set(id, { multiplier, disabled });
+		}
+		return result;
+	} catch {
+		return new Map();
+	}
+}

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -4,7 +4,38 @@ import { spawn, spawnSync } from "child_process";
 import { getBinDir, getSettingsPath } from "../config.js";
 import { SettingsManager } from "../core/settings-manager.js";
 
-let cachedShellConfig: { shell: string; args: string[] } | null = null;
+export type ShellExecutionMode = "tool" | "user";
+
+let cachedShellConfigs = new Map<ShellExecutionMode, { shell: string; args: string[] }>();
+
+function getShellBasename(shellPath: string): string {
+	const normalized = shellPath.replace(/\\/g, "/");
+	return normalized.split("/").pop()?.toLowerCase() ?? normalized.toLowerCase();
+}
+
+export function getShellArgs(shellPath: string, mode: ShellExecutionMode): string[] {
+	if (mode === "tool") {
+		return ["-c"];
+	}
+
+	const shell = getShellBasename(shellPath);
+	if (
+		shell === "bash" ||
+		shell === "zsh" ||
+		shell === "fish" ||
+		shell === "ksh" ||
+		shell === "mksh" ||
+		shell === "pdksh" ||
+		shell === "csh" ||
+		shell === "tcsh" ||
+		shell === "nu" ||
+		shell === "nushell"
+	) {
+		return ["-i", "-c"];
+	}
+
+	return ["-c"];
+}
 
 /**
  * Find bash executable on PATH (cross-platform)
@@ -44,13 +75,20 @@ function findBashOnPath(): string | null {
 /**
  * Get shell configuration based on platform.
  * Resolution order:
+ * Tool mode:
  * 1. User-specified shellPath in settings.json
  * 2. On Windows: Git Bash in known locations, then bash on PATH
  * 3. On Unix: /bin/bash, then bash on PATH, then fallback to sh
+ *
+ * User mode:
+ * 1. User-specified shellPath in settings.json
+ * 2. On Unix: $SHELL when it exists
+ * 3. Fall back to tool-mode resolution
  */
-export function getShellConfig(): { shell: string; args: string[] } {
-	if (cachedShellConfig) {
-		return cachedShellConfig;
+export function getShellConfig(mode: ShellExecutionMode = "tool"): { shell: string; args: string[] } {
+	const cached = cachedShellConfigs.get(mode);
+	if (cached) {
+		return cached;
 	}
 
 	const settings = SettingsManager.create();
@@ -59,12 +97,22 @@ export function getShellConfig(): { shell: string; args: string[] } {
 	// 1. Check user-specified shell path
 	if (customShellPath) {
 		if (existsSync(customShellPath)) {
-			cachedShellConfig = { shell: customShellPath, args: ["-c"] };
-			return cachedShellConfig;
+			const config = { shell: customShellPath, args: getShellArgs(customShellPath, mode) };
+			cachedShellConfigs.set(mode, config);
+			return config;
 		}
 		throw new Error(
 			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ${getSettingsPath()}`,
 		);
+	}
+
+	if (mode === "user" && process.platform !== "win32") {
+		const envShell = process.env.SHELL;
+		if (envShell && existsSync(envShell)) {
+			const config = { shell: envShell, args: getShellArgs(envShell, mode) };
+			cachedShellConfigs.set(mode, config);
+			return config;
+		}
 	}
 
 	if (process.platform === "win32") {
@@ -81,16 +129,18 @@ export function getShellConfig(): { shell: string; args: string[] } {
 
 		for (const path of paths) {
 			if (existsSync(path)) {
-				cachedShellConfig = { shell: path, args: ["-c"] };
-				return cachedShellConfig;
+				const config = { shell: path, args: getShellArgs(path, mode) };
+				cachedShellConfigs.set(mode, config);
+				return config;
 			}
 		}
 
 		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
 		const bashOnPath = findBashOnPath();
 		if (bashOnPath) {
-			cachedShellConfig = { shell: bashOnPath, args: ["-c"] };
-			return cachedShellConfig;
+			const config = { shell: bashOnPath, args: getShellArgs(bashOnPath, mode) };
+			cachedShellConfigs.set(mode, config);
+			return config;
 		}
 
 		throw new Error(
@@ -104,18 +154,25 @@ export function getShellConfig(): { shell: string; args: string[] } {
 
 	// Unix: try /bin/bash, then bash on PATH, then fallback to sh
 	if (existsSync("/bin/bash")) {
-		cachedShellConfig = { shell: "/bin/bash", args: ["-c"] };
-		return cachedShellConfig;
+		const config = { shell: "/bin/bash", args: getShellArgs("/bin/bash", mode) };
+		cachedShellConfigs.set(mode, config);
+		return config;
 	}
 
 	const bashOnPath = findBashOnPath();
 	if (bashOnPath) {
-		cachedShellConfig = { shell: bashOnPath, args: ["-c"] };
-		return cachedShellConfig;
+		const config = { shell: bashOnPath, args: getShellArgs(bashOnPath, mode) };
+		cachedShellConfigs.set(mode, config);
+		return config;
 	}
 
-	cachedShellConfig = { shell: "sh", args: ["-c"] };
-	return cachedShellConfig;
+	const config = { shell: "sh", args: getShellArgs("sh", mode) };
+	cachedShellConfigs.set(mode, config);
+	return config;
+}
+
+export function resetShellConfigCache(): void {
+	cachedShellConfigs = new Map();
 }
 
 export function getShellEnv(): NodeJS.ProcessEnv {

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -99,6 +99,79 @@ describe("InteractiveMode.setToolsExpanded", () => {
 	});
 });
 
+describe("InteractiveMode.handleThinkingCommand", () => {
+	test("opens the thinking selector when no level is provided", () => {
+		const fakeThis: any = {
+			showThinkingSelector: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.handleThinkingCommand.call(fakeThis);
+
+		expect(fakeThis.showThinkingSelector).toHaveBeenCalledTimes(1);
+	});
+
+	test("applies a valid thinking level and refreshes related UI", () => {
+		const fakeThis: any = {
+			session: {
+				getAvailableThinkingLevels: vi.fn(() => ["off", "minimal", "low", "medium", "high", "xhigh"]),
+				setThinkingLevel: vi.fn(),
+			},
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.handleThinkingCommand.call(fakeThis, "high");
+
+		expect(fakeThis.session.setThinkingLevel).toHaveBeenCalledWith("high");
+		expect(fakeThis.footer.invalidate).toHaveBeenCalledTimes(1);
+		expect(fakeThis.updateEditorBorderColor).toHaveBeenCalledTimes(1);
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("Thinking level: high");
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
+	test("shows an error for invalid thinking levels", () => {
+		const fakeThis: any = {
+			session: {
+				getAvailableThinkingLevels: vi.fn(() => ["off", "minimal", "low", "medium", "high", "xhigh"]),
+				setThinkingLevel: vi.fn(),
+			},
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.handleThinkingCommand.call(fakeThis, "turbo");
+
+		expect(fakeThis.session.setThinkingLevel).not.toHaveBeenCalled();
+		expect(fakeThis.showError).toHaveBeenCalledWith(
+			'Invalid thinking level "turbo". Valid values: off, minimal, low, medium, high, xhigh',
+		);
+		expect(fakeThis.showStatus).not.toHaveBeenCalled();
+	});
+
+	test("shows a status when the current model does not support thinking", () => {
+		const fakeThis: any = {
+			session: {
+				getAvailableThinkingLevels: vi.fn(() => ["off"]),
+				setThinkingLevel: vi.fn(),
+			},
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.handleThinkingCommand.call(fakeThis, "high");
+
+		expect(fakeThis.session.setThinkingLevel).not.toHaveBeenCalled();
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("Current model does not support thinking");
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+});
+
 describe("InteractiveMode.createExtensionUIContext setTheme", () => {
 	test("persists theme changes to settings manager", () => {
 		initTheme("dark");
@@ -212,6 +285,8 @@ describe("InteractiveMode.showLoadedResources", () => {
 			) => (InteractiveMode as any).prototype.getCompactNonPackageExtensionLabel.call(fakeThis, p, index, allPaths),
 			getCompactExtensionLabels: (extensions: ExtensionFixture[]) =>
 				(InteractiveMode as any).prototype.getCompactExtensionLabels.call(fakeThis, extensions),
+			formatDiagnosticsCompact: (label: string, diagnostics: Array<{ type: "warning" | "error" | "collision" }>) =>
+				(InteractiveMode as any).prototype.formatDiagnosticsCompact.call(fakeThis, label, diagnostics),
 			formatDiagnostics: () => "diagnostics",
 			getBuiltInCommandConflictDiagnostics: () => [],
 		};
@@ -409,7 +484,7 @@ describe("InteractiveMode.showLoadedResources", () => {
 
 		expect(normalizeRenderedOutput(fakeThis.chatContainer)).toMatchInlineSnapshot(`
 "[Extensions]
-  @scope/pi-scoped, answer.ts, cli-extension.ts, HazAT/pi-interactive-subagents, HazAT/pi-interactive-subagents:subagents, local-index/index.ts, pi-markdown-preview, user-index/index.ts"`);
+   @scope/pi-scoped, answer.ts, cli-extension.ts, HazAT/pi-interactive-subagents, HazAT/pi-interactive-subagents:subagents, local-index/index.ts, pi-markdown-preview, user-index/index.ts"`);
 	});
 
 	test("adds more parent folders until local extension labels are unique", () => {
@@ -455,7 +530,7 @@ describe("InteractiveMode.showLoadedResources", () => {
 
 		expect(normalizeRenderedOutput(fakeThis.chatContainer)).toMatchInlineSnapshot(`
 "[Extensions]
-  alpha/one/index.ts, beta/one/index.ts, gamma/one/index.ts"`);
+   alpha/one/index.ts, beta/one/index.ts, gamma/one/index.ts"`);
 	});
 
 	test("captures mixed extension layouts in expanded output", () => {
@@ -472,20 +547,20 @@ describe("InteractiveMode.showLoadedResources", () => {
 
 		expect(normalizeRenderedOutput(fakeThis.chatContainer)).toMatchInlineSnapshot(`
 "[Extensions]
-  project
-    /tmp/project/.pi/extensions/answer.ts
-    /tmp/project/.pi/extensions/local-index/index.ts
-    git:github.com/HazAT/pi-interactive-subagents
-      extensions/index.ts
-      extensions/subagents/index.ts
-    npm:@scope/pi-scoped
-      extensions/index.ts
-    npm:pi-markdown-preview
-      extensions/index.ts
-  user
-    /tmp/agent/extensions/user-index/index.ts
-  path
-    /tmp/temp/cli-extension.ts"`);
+   project
+     /tmp/project/.pi/extensions/answer.ts
+     /tmp/project/.pi/extensions/local-index/index.ts
+     git:github.com/HazAT/pi-interactive-subagents
+       extensions/index.ts
+       extensions/subagents/index.ts
+     npm:@scope/pi-scoped
+       extensions/index.ts
+     npm:pi-markdown-preview
+       extensions/index.ts
+   user
+     /tmp/agent/extensions/user-index/index.ts
+   path
+     /tmp/temp/cli-extension.ts"`);
 	});
 
 	test("shows context paths relative to cwd while preserving full external paths", () => {
@@ -555,8 +630,8 @@ describe("InteractiveMode.showLoadedResources", () => {
 			showDiagnosticsWhenQuiet: true,
 		});
 
-		const output = renderAll(fakeThis.chatContainer);
-		expect(output).toContain("[Skill conflicts]");
+		const output = renderAll(fakeThis.chatContainer).replace(/\u001b\[[0-9;]*m/g, "");
+		expect(output).toContain("⚠ Skills");
 		expect(output).not.toContain("[Skills]");
 	});
 });

--- a/packages/coding-agent/test/interactive-shell-layout.test.ts
+++ b/packages/coding-agent/test/interactive-shell-layout.test.ts
@@ -26,6 +26,10 @@ function lineComponent(...lines: string[]) {
 	};
 }
 
+function stripAnsi(value: string | undefined): string {
+	return (value ?? "").replace(/\u001b\[[0-9;]*m/g, "");
+}
+
 function createSession(): AgentSession {
 	const session = {
 		model: {
@@ -156,6 +160,34 @@ describe("interactive shell layout primitives", () => {
 		expect(composerLine).toContain("@files");
 		expect(composerLine.startsWith(" ")).toBe(true);
 		expect(visibleWidth(composerLine)).toBe(40);
+		expect(rendered[2]).toBe(" ".repeat(40));
+	});
+
+	it("keeps slash-command autocomplete but drops the lower composer rule", () => {
+		const tui = {
+			terminal: { rows: 24, columns: 80 },
+			requestRender: vi.fn(),
+		} as unknown as TUI;
+		const editor = new CustomEditor(tui, getEditorTheme(), KeybindingsManager.create(), {
+			paddingX: 1,
+			placeholder: "Ask piper, add @files, or use /commands",
+		});
+
+		editor.setText("/");
+		editor.focused = true;
+		Object.assign(editor as unknown as object, {
+			autocompleteState: "regular",
+			autocompleteList: {
+				render: () => ["> settings", "  model"],
+			},
+		});
+
+		const rendered = editor.render(40);
+		expect(rendered).toHaveLength(5);
+		expect(rendered[1]).toContain("/");
+		expect(rendered[2]).toBe(" ".repeat(40));
+		expect(rendered[3]).toContain("> settings");
+		expect(rendered[4]).toContain("model");
 	});
 
 	it("renders a full-height sidebar with contextual sections", () => {
@@ -163,7 +195,6 @@ describe("interactive shell layout primitives", () => {
 		sidebar.setHeight(30);
 		sidebar.setResourceSections([
 			{ label: "Copilot Budget", value: "25%", order: 20, color: "success" } as any,
-			{ label: "Premium", value: "25 / 100 requests", order: 20 } as any,
 			{ label: "Context File", value: "AGENTS.md", order: 30 } as any,
 			{ label: "Skills", value: "review, write", order: 40 } as any,
 		]);
@@ -172,9 +203,9 @@ describe("interactive shell layout primitives", () => {
 		expect(sidebar.render(30)).toHaveLength(30);
 		expect(rendered).toContain("claude-sonnet-4.6");
 		expect(rendered).toContain("Investigate Copilot sidebar");
+		expect(rendered).toContain("x1");
 		expect(rendered).toContain("Usage");
 		expect(rendered).toContain("25%");
-		expect(rendered).toContain("Premium");
 		expect(rendered).toContain("main");
 		expect(rendered).toContain("Skills");
 	});
@@ -199,6 +230,18 @@ describe("interactive shell layout primitives", () => {
 		expect(rendered).toContain("123k / 1.0M");
 	});
 
+	it("adds breathing room between context usage and context resource rows", () => {
+		const sidebar = new ShellSidebarComponent(createSession(), createFooterData());
+		sidebar.setHeight(24);
+		sidebar.setResourceSections([{ label: "Context File", value: "AGENTS.md", order: 30 } as any]);
+
+		const lines = sidebar.render(30);
+		const contextSummaryIndex = lines.findIndex((line) => line.includes("123k / 1.0M"));
+		expect(contextSummaryIndex).toBeGreaterThanOrEqual(0);
+		expect(stripAnsi(lines[contextSummaryIndex + 1]).trim()).toBe("│");
+		expect(lines[contextSummaryIndex + 2]).toContain("Context File");
+	});
+
 	it("uses dividers and short workspace labels in the sidebar", () => {
 		const sidebar = new ShellSidebarComponent(createSession(), createFooterData());
 		sidebar.setHeight(24);
@@ -207,6 +250,17 @@ describe("interactive shell layout primitives", () => {
 		expect(rendered).toContain("Workspace");
 		expect(rendered).toContain("project");
 		expect(rendered).not.toContain("/Users/test/project");
+	});
+
+	it("renders workspace as a footer section with bottom padding", () => {
+		const sidebar = new ShellSidebarComponent(createSession(), createFooterData());
+		sidebar.setHeight(30);
+		const lines = sidebar.render(30);
+		const workspaceIndex = lines.findIndex((line) => stripAnsi(line).includes("Workspace"));
+		expect(workspaceIndex).toBeGreaterThanOrEqual(0);
+		expect(stripAnsi(lines[workspaceIndex - 2])).toContain("─");
+		expect(stripAnsi(lines[workspaceIndex - 1]).trim()).toBe("│");
+		expect(stripAnsi(lines.at(-1))).toBe(" ".repeat(30));
 	});
 
 	it("skips malformed sidebar sections instead of crashing", () => {
@@ -541,7 +595,6 @@ describe("copilot budget sidebar helpers", () => {
 			}),
 		).toEqual([
 			{ label: "Copilot Budget", value: "37%", color: "success" },
-			{ label: "Premium", value: "372 / 1000 requests" },
 			{ label: "Reset", value: "May 1" },
 		]);
 	});

--- a/packages/coding-agent/test/interactive-shell-layout.test.ts
+++ b/packages/coding-agent/test/interactive-shell-layout.test.ts
@@ -1,4 +1,4 @@
-import { Container } from "@mariozechner/pi-tui";
+import { Container, CURSOR_MARKER, type TUI } from "@mariozechner/pi-tui";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { BottomDockLayout } from "../../tui/src/components/bottom-dock-layout.js";
 import { HorizontalSplit } from "../../tui/src/components/horizontal-split.js";
@@ -11,11 +11,13 @@ import {
 } from "../examples/extensions/copilot-budget.js";
 import type { AgentSession } from "../src/core/agent-session.js";
 import type { ReadonlyFooterDataProvider } from "../src/core/footer-data-provider.js";
+import { KeybindingsManager } from "../src/core/keybindings.js";
+import { CustomEditor } from "../src/modes/interactive/components/custom-editor.js";
 import { renderDiff } from "../src/modes/interactive/components/diff.js";
 import { ShellDockComponent } from "../src/modes/interactive/components/shell-dock.js";
 import { ShellSidebarComponent } from "../src/modes/interactive/components/shell-sidebar.js";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
-import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { getEditorTheme, initTheme } from "../src/modes/interactive/theme/theme.js";
 
 function lineComponent(...lines: string[]) {
 	return {
@@ -134,9 +136,31 @@ describe("interactive shell layout primitives", () => {
 		expect(dock.render(80)).toEqual(["hints", "transient-1", "transient-2", "editor-1", "editor-2", "footer"]);
 	});
 
+	it("renders a padded placeholder for an empty composer", () => {
+		const tui = {
+			terminal: { rows: 24, columns: 80 },
+			requestRender: vi.fn(),
+		} as unknown as TUI;
+		const editor = new CustomEditor(tui, getEditorTheme(), KeybindingsManager.create(), {
+			paddingX: 1,
+			placeholder: "Ask piper, add @files, or use /commands",
+		});
+
+		editor.focused = true;
+
+		const rendered = editor.render(40);
+		const composerLine = rendered[1] ?? "";
+		expect(rendered).toHaveLength(3);
+		expect(composerLine).toContain(CURSOR_MARKER);
+		expect(composerLine).toContain("Ask piper");
+		expect(composerLine).toContain("@files");
+		expect(composerLine.startsWith(" ")).toBe(true);
+		expect(visibleWidth(composerLine)).toBe(40);
+	});
+
 	it("renders a full-height sidebar with contextual sections", () => {
 		const sidebar = new ShellSidebarComponent(createSession(), createFooterData());
-		sidebar.setHeight(26);
+		sidebar.setHeight(30);
 		sidebar.setResourceSections([
 			{ label: "Copilot Budget", value: "25%", order: 20, color: "success" } as any,
 			{ label: "Premium", value: "25 / 100 requests", order: 20 } as any,
@@ -145,7 +169,7 @@ describe("interactive shell layout primitives", () => {
 		]);
 
 		const rendered = sidebar.render(30).join("\n");
-		expect(sidebar.render(30)).toHaveLength(26);
+		expect(sidebar.render(30)).toHaveLength(30);
 		expect(rendered).toContain("claude-sonnet-4.6");
 		expect(rendered).toContain("Investigate Copilot sidebar");
 		expect(rendered).toContain("Usage");
@@ -177,7 +201,7 @@ describe("interactive shell layout primitives", () => {
 
 	it("uses dividers and short workspace labels in the sidebar", () => {
 		const sidebar = new ShellSidebarComponent(createSession(), createFooterData());
-		sidebar.setHeight(20);
+		sidebar.setHeight(24);
 		const rendered = sidebar.render(30).join("\n");
 		expect(rendered).toContain("─");
 		expect(rendered).toContain("Workspace");

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -156,6 +156,45 @@ Project skill`,
 			expect(theme?.sourcePath).toBe(projectThemePath);
 		});
 
+		it("reloads project resources from the updated cwd", async () => {
+			const projectOne = join(tempDir, "project-one");
+			const projectTwo = join(tempDir, "project-two");
+			const settingsManager = SettingsManager.create(projectOne, agentDir);
+
+			mkdirSync(join(projectOne, ".pi", "prompts"), { recursive: true });
+			mkdirSync(join(projectTwo, ".pi", "prompts"), { recursive: true });
+			writeFileSync(
+				join(projectOne, ".pi", "prompts", "one.md"),
+				`---
+description: Prompt one
+---
+Project one prompt.`,
+			);
+			writeFileSync(
+				join(projectTwo, ".pi", "prompts", "two.md"),
+				`---
+description: Prompt two
+---
+Project two prompt.`,
+			);
+
+			const loader = new DefaultResourceLoader({
+				cwd: projectOne,
+				agentDir,
+				settingsManager,
+			});
+			await loader.reload();
+			expect(loader.getPrompts().prompts.map((prompt) => prompt.name)).toContain("one");
+			expect(loader.getPrompts().prompts.map((prompt) => prompt.name)).not.toContain("two");
+
+			settingsManager.setCwd(projectTwo, agentDir);
+			loader.setCwd(projectTwo);
+			await loader.reload();
+
+			expect(loader.getPrompts().prompts.map((prompt) => prompt.name)).toContain("two");
+			expect(loader.getPrompts().prompts.map((prompt) => prompt.name)).not.toContain("one");
+		});
+
 		it("should keep both extensions loaded when command names collide", async () => {
 			const userExtDir = join(agentDir, "extensions");
 			const projectExtDir = join(cwd, ".pi", "extensions");

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -206,3 +206,32 @@ describe("SessionManager.setSessionFile with corrupted files", () => {
 		expect(sm2.getHeader()?.type).toBe("session");
 	});
 });
+
+describe("SessionManager.setCwd", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `session-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("updates the in-memory cwd and persisted session header", () => {
+		const sessionManager = SessionManager.create(join(tempDir, "project-a"), tempDir);
+		const sessionFile = sessionManager.getSessionFile();
+
+		expect(sessionFile).toBeTruthy();
+
+		sessionManager.setCwd(join(tempDir, "project-b"));
+
+		expect(sessionManager.getCwd()).toBe(join(tempDir, "project-b"));
+
+		const fileContent = readFileSync(sessionFile!, "utf-8").trim();
+		const header = JSON.parse(fileContent) as { cwd: string; type: string };
+		expect(header.type).toBe("session");
+		expect(header.cwd).toBe(join(tempDir, "project-b"));
+	});
+});

--- a/packages/coding-agent/test/shell-config.test.ts
+++ b/packages/coding-agent/test/shell-config.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getShellArgs, resetShellConfigCache } from "../src/utils/shell.js";
+
+describe("shell config helpers", () => {
+	afterEach(() => {
+		resetShellConfigCache();
+	});
+
+	it("keeps tool shell execution non-interactive", () => {
+		expect(getShellArgs("/bin/bash", "tool")).toEqual(["-c"]);
+		expect(getShellArgs("/bin/zsh", "tool")).toEqual(["-c"]);
+	});
+
+	it("uses interactive command mode for user shells that load shell setup", () => {
+		expect(getShellArgs("/bin/zsh", "user")).toEqual(["-i", "-c"]);
+		expect(getShellArgs("/bin/bash", "user")).toEqual(["-i", "-c"]);
+		expect(getShellArgs("/opt/homebrew/bin/fish", "user")).toEqual(["-i", "-c"]);
+	});
+
+	it("falls back to plain command mode for unknown shells", () => {
+		expect(getShellArgs("/usr/bin/sh", "user")).toEqual(["-c"]);
+		expect(getShellArgs("/custom/shells/xonsh", "user")).toEqual(["-c"]);
+	});
+});

--- a/packages/coding-agent/test/user-shell-session.test.ts
+++ b/packages/coding-agent/test/user-shell-session.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createUserShellScript, parseUserShellEndLine } from "../src/modes/interactive/user-shell-session.js";
+
+describe("createUserShellScript", () => {
+	it("wraps posix commands with start/end markers and interrupt handling", () => {
+		const script = createUserShellScript("cd ../repo\npwd", "cmd-1", "posix");
+
+		expect(script).toContain("__PIPER_USER_SHELL_START__cmd-1__");
+		expect(script).toContain("__PIPER_USER_SHELL_END__cmd-1__");
+		expect(script).toContain("trap '__piper_interrupted=130' INT");
+		expect(script).toContain("cd ../repo");
+	});
+
+	it("wraps fish commands with fish status tracking", () => {
+		const script = createUserShellScript("cd ../repo\npwd", "cmd-2", "fish");
+
+		expect(script).toContain("__PIPER_USER_SHELL_START__cmd-2__");
+		expect(script).toContain("__PIPER_USER_SHELL_END__cmd-2__");
+		expect(script).toContain("set -l __piper_exit $status");
+		expect(script).toContain("set -l __piper_cwd (pwd)");
+	});
+});
+
+describe("parseUserShellEndLine", () => {
+	it("parses exit code and cwd from the command footer", () => {
+		const parsed = parseUserShellEndLine("__PIPER_USER_SHELL_END__cmd-3__\t7\t/tmp/my repo", "cmd-3");
+
+		expect(parsed).toEqual({
+			exitCode: 7,
+			cwd: "/tmp/my repo",
+		});
+	});
+
+	it("returns undefined for lines from a different command", () => {
+		expect(parseUserShellEndLine("__PIPER_USER_SHELL_END__other__\t0\t/tmp", "cmd-4")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Implements intelligent skill management to reduce context bloat. Users can now selectively enable/disable skills per-project, removing disabled skill descriptions from the system prompt while keeping them invokable via `/skill:name`.

## Key Features

- **`/skills` command**: Interactive TUI selector with fuzzy search, checkbox list, and keybinding support
- **Skill filtering**: Disabled skills are excluded from system prompt XML injection (context savings)
- **Project persistence**: Disabled skill list saved to `.pi/settings.json` per-project
- **Sidebar integration**: Shows active skill count (e.g., "Skills: 30/60 active")
- **Still invokable**: Disabled skills remain callable via `/skill:name` for edge cases

## Changes

### Core Integration
- `settings-manager.ts`: Added `disabledSkills` property and getter/setter methods
- `skills.ts`: Filter skills before formatting for prompt injection
- `system-prompt.ts`: Thread disabled skills through prompt building pipeline
- `agent-session.ts`: Read disabled skills and rebuild prompt on toggle
- `keybindings.ts`: Added configurable keybindings for skill selector

### UI Components
- **New**: `skill-selector.ts` — Interactive selector component with fuzzy search and checkboxes
- `thinking-selector.ts`: Removed inconsistent bottom border
- `custom-editor.ts`: Changed cursor character to π symbol

### Interactive Mode
- `/skills` slash command routing and handler
- `showSkillSelector()` method with sidebar refresh integration

## Testing

- ✅ `bun run check` passes with no errors
- ✅ Tested with 60+ installed skills  
- ✅ Verified sidebar updates on skill toggle
- ✅ Confirmed disabled skills persist across sessions
- ✅ Confirmed disabled skills invokable via `/skill:name`
