### PR TITLE
feat(coding-agent): plan/edit modes, confirm gating, and UI performance

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -70,6 +70,12 @@ import {
 } from "./extensions/index.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
+import {
+	buildPlanningContextMessage,
+	createTurnPlanContext,
+	type TurnPlanContext,
+	type TurnPlanningMode,
+} from "./planning.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
@@ -77,10 +83,11 @@ import { CURRENT_SESSION_VERSION, getLatestCompactionEntry, type SessionHeader }
 import type { SettingsManager } from "./settings-manager.js";
 import type { SlashCommandInfo } from "./slash-commands.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.js";
-import { buildSubagentSchedulerPlan } from "./subagents/scheduler.js";
+import { buildSubagentSchedulerPlan, shouldAutoPlanForSchedulePlan } from "./subagents/scheduler.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
+import { resolveToCwd } from "./tools/path-utils.js";
 import { createToolDefinitionFromAgentTool, wrapToolDefinition } from "./tools/tool-definition-wrapper.js";
 
 // ============================================================================
@@ -267,7 +274,10 @@ export class AgentSession {
 	private _retryResolve: (() => void) | undefined = undefined;
 	private _turnMutationStarted = false;
 	private _turnExplorationCount = 0;
+	private _turnEditApprovalGranted = false;
 	private _explorationNudgeActive = false;
+	private _currentPlanningMode: TurnPlanningMode = "off";
+	private _currentTurnPlanContext: TurnPlanContext | undefined = undefined;
 
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
@@ -299,6 +309,7 @@ export class AgentSession {
 	private _toolDefinitions: Map<string, ToolDefinitionEntry> = new Map();
 	private _toolPromptSnippets: Map<string, string> = new Map();
 	private _toolPromptGuidelines: Map<string, string[]> = new Map();
+	private _configuredActiveToolNames: string[] = [];
 
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
@@ -314,6 +325,7 @@ export class AgentSession {
 		this._modelRegistry = config.modelRegistry;
 		this._extensionRunnerRef = config.extensionRunnerRef;
 		this._initialActiveToolNames = config.initialActiveToolNames;
+		this._configuredActiveToolNames = config.initialActiveToolNames ? [...config.initialActiveToolNames] : [];
 		this._baseToolsOverride = config.baseToolsOverride;
 		this._sessionStartEvent = config.sessionStartEvent ?? { type: "session_start", reason: "startup" };
 
@@ -331,6 +343,74 @@ export class AgentSession {
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
 		return this._modelRegistry;
+	}
+
+	private _getRequiredToolNames(): string[] {
+		return this.settingsManager.getEditMode() ? [] : ["confirm"];
+	}
+
+	private _resolveRuntimeToolNames(toolNames: readonly string[]): string[] {
+		return [...new Set([...toolNames, ...this._getRequiredToolNames()])];
+	}
+
+	private _applyConfiguredTools(): void {
+		const runtimeToolNames = this._resolveRuntimeToolNames(this._configuredActiveToolNames);
+		const tools: AgentTool[] = [];
+		const validRuntimeToolNames: string[] = [];
+		const isSubagentChild = parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) > 0;
+		for (const name of runtimeToolNames) {
+			if (isSubagentChild && name === "subagent") {
+				continue;
+			}
+			const tool = this._toolRegistry.get(name);
+			if (tool) {
+				tools.push(tool);
+				validRuntimeToolNames.push(name);
+			}
+		}
+		this.agent.state.tools = tools;
+		this._baseSystemPrompt = this._rebuildSystemPrompt(validRuntimeToolNames);
+		this.agent.state.systemPrompt = this._baseSystemPrompt;
+	}
+
+	private _getToolPath(args: unknown): string | undefined {
+		if (!args || typeof args !== "object" || !("path" in args)) {
+			return undefined;
+		}
+		return typeof args.path === "string" ? args.path : undefined;
+	}
+
+	private _isPlanningFilePath(filePath: string | undefined): boolean {
+		if (!filePath || !this._currentTurnPlanContext) {
+			return false;
+		}
+		const resolvedPath = resolveToCwd(filePath, this._cwd);
+		const plansRoot = resolve(this._cwd, ".plans");
+		return (
+			resolvedPath === plansRoot ||
+			resolvedPath.startsWith(`${plansRoot}/`) ||
+			resolvedPath.startsWith(`${plansRoot}\\`)
+		);
+	}
+
+	private _isRepoMutation(toolName: string, args: unknown): boolean {
+		if (toolName !== "edit" && toolName !== "write") {
+			return false;
+		}
+		return !this._isPlanningFilePath(this._getToolPath(args));
+	}
+
+	private _toolResultText(content: Array<{ type: string; text?: string }> | undefined): string {
+		if (!content) {
+			return "";
+		}
+		return content
+			.filter(
+				(part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string",
+			)
+			.map((part) => part.text)
+			.join("\n")
+			.trim();
 	}
 
 	private async _getRequiredRequestAuth(model: Model<any>): Promise<{
@@ -372,31 +452,42 @@ export class AgentSession {
 		const EXPLORATION_NUDGE_THRESHOLD = 5;
 
 		this.agent.beforeToolCall = async ({ toolCall, args }) => {
-			if (toolCall.name === "edit" || toolCall.name === "write") {
-				this._turnMutationStarted = true;
-			}
 			if (EXPLORATION_TOOLS.has(toolCall.name)) {
 				this._turnExplorationCount++;
 				if (this._turnExplorationCount >= EXPLORATION_NUDGE_THRESHOLD && !this._explorationNudgeActive) {
 					this._explorationNudgeActive = true;
-					this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
-					this.agent.state.systemPrompt = this._baseSystemPrompt;
+					this.rebuildSystemPrompt();
 				}
+			}
+			const isRepoMutation = this._isRepoMutation(toolCall.name, args);
+			if (isRepoMutation && !this.settingsManager.getEditMode() && !this._turnEditApprovalGranted) {
+				return {
+					block: true,
+					reason:
+						"Edit mode is off. Use the confirm tool to ask for permission before editing files outside .plans.",
+				};
 			}
 			const runner = this._extensionRunner;
 			if (!runner?.hasHandlers("tool_call")) {
+				if (isRepoMutation) {
+					this._turnMutationStarted = true;
+				}
 				return undefined;
 			}
 
 			await this._agentEventQueue;
 
 			try {
-				return await runner.emitToolCall({
+				const hookResult = await runner.emitToolCall({
 					type: "tool_call",
 					toolName: toolCall.name,
 					toolCallId: toolCall.id,
 					input: args as Record<string, unknown>,
 				});
+				if (!hookResult?.block && isRepoMutation) {
+					this._turnMutationStarted = true;
+				}
+				return hookResult;
 			} catch (err) {
 				if (err instanceof Error) {
 					throw err;
@@ -407,7 +498,13 @@ export class AgentSession {
 
 		this.agent.afterToolCall = async ({ toolCall, args, result, isError }) => {
 			const runner = this._extensionRunner;
+			let finalContent = result.content;
+			let finalDetails = result.details;
+			let finalIsError = isError;
 			if (!runner?.hasHandlers("tool_result")) {
+				if (toolCall.name === "confirm" && !finalIsError && this._toolResultText(finalContent) === "confirmed") {
+					this._turnEditApprovalGranted = true;
+				}
 				return undefined;
 			}
 
@@ -422,13 +519,23 @@ export class AgentSession {
 			});
 
 			if (!hookResult) {
+				if (toolCall.name === "confirm" && !finalIsError && this._toolResultText(finalContent) === "confirmed") {
+					this._turnEditApprovalGranted = true;
+				}
 				return undefined;
 			}
 
+			finalContent = hookResult.content ?? result.content;
+			finalDetails = hookResult.details ?? result.details;
+			finalIsError = hookResult.isError ?? isError;
+			if (toolCall.name === "confirm" && !finalIsError && this._toolResultText(finalContent) === "confirmed") {
+				this._turnEditApprovalGranted = true;
+			}
+
 			return {
-				content: hookResult.content,
-				details: hookResult.details,
-				isError: hookResult.isError ?? isError,
+				content: finalContent,
+				details: finalDetails,
+				isError: finalIsError,
 			};
 		};
 	}
@@ -783,6 +890,14 @@ export class AgentSession {
 		return this.agent.state.tools.map((t) => t.name);
 	}
 
+	get planningModeStatus(): TurnPlanningMode {
+		return this.settingsManager.getPlanMode() ? "manual" : this._currentPlanningMode;
+	}
+
+	get editModeEnabled(): boolean {
+		return this.settingsManager.getEditMode();
+	}
+
 	/**
 	 * Get all configured tools with name, description, parameter schema, and source metadata.
 	 */
@@ -806,24 +921,14 @@ export class AgentSession {
 	 * Changes take effect on the next agent turn.
 	 */
 	setActiveToolsByName(toolNames: string[]): void {
-		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];
-		const isSubagentChild = parseInt(process.env.PI_SUBAGENT_DEPTH ?? "0", 10) > 0;
 		for (const name of toolNames) {
-			if (isSubagentChild && name === "subagent") {
-				continue;
-			}
-			const tool = this._toolRegistry.get(name);
-			if (tool) {
-				tools.push(tool);
+			if (this._toolRegistry.has(name)) {
 				validToolNames.push(name);
 			}
 		}
-		this.agent.state.tools = tools;
-
-		// Rebuild base system prompt with new tool set
-		this._baseSystemPrompt = this._rebuildSystemPrompt(validToolNames);
-		this.agent.state.systemPrompt = this._baseSystemPrompt;
+		this._configuredActiveToolNames = [...new Set(validToolNames)];
+		this._applyConfiguredTools();
 	}
 
 	/** Whether compaction or branch summarization is currently running */
@@ -938,7 +1043,8 @@ export class AgentSession {
 			selectedTools: validToolNames,
 			toolSnippets,
 			promptGuidelines,
-			teamMode: this.settingsManager.getTeamMode(),
+			planMode: this.settingsManager.getPlanMode(),
+			editMode: this.settingsManager.getEditMode(),
 			explorationNudge: this._explorationNudgeActive,
 		});
 	}
@@ -1051,21 +1157,46 @@ export class AgentSession {
 			const mutationStarted = this._turnMutationStarted;
 			this._turnMutationStarted = false;
 			this._turnExplorationCount = 0;
+			this._turnEditApprovalGranted = false;
+			this._currentPlanningMode = "off";
+			this._currentTurnPlanContext = undefined;
 			if (this._explorationNudgeActive) {
 				this._explorationNudgeActive = false;
-				this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
-				this.agent.state.systemPrompt = this._baseSystemPrompt;
+				this.rebuildSystemPrompt();
 			}
 
 			// Build messages array (scheduler/custom context first, then user message)
 			messages = [];
 
+			const activeToolNames = this.getActiveToolNames();
 			const schedulerPlan = buildSubagentSchedulerPlan({
 				cwd: this._cwd,
 				prompt: expandedText,
-				activeToolNames: this.getActiveToolNames(),
+				activeToolNames,
 				mutationStarted,
 			});
+			const planningMode: TurnPlanningMode = this.settingsManager.getPlanMode()
+				? "manual"
+				: shouldAutoPlanForSchedulePlan(schedulerPlan)
+					? "auto"
+					: "off";
+			this._currentPlanningMode = planningMode;
+			if (planningMode !== "off") {
+				this._currentTurnPlanContext = createTurnPlanContext(this._cwd, expandedText, planningMode);
+				messages.push({
+					role: "custom",
+					customType: "planning_context",
+					content: buildPlanningContextMessage(this._currentTurnPlanContext, this.settingsManager.getEditMode()),
+					display: false,
+					details: {
+						mode: planningMode,
+						path: this._currentTurnPlanContext.path,
+						template: this._currentTurnPlanContext.template,
+						editMode: this.settingsManager.getEditMode(),
+					},
+					timestamp: Date.now(),
+				});
+			}
 			if (schedulerPlan) {
 				messages.push({
 					role: "custom",
@@ -1416,8 +1547,7 @@ export class AgentSession {
 	}
 
 	rebuildSystemPrompt(): void {
-		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
-		this.agent.state.systemPrompt = this._baseSystemPrompt;
+		this._applyConfiguredTools();
 	}
 
 	/**
@@ -2126,8 +2256,7 @@ export class AgentSession {
 		};
 
 		this._resourceLoader.extendResources(extensionPaths);
-		this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
-		this.agent.state.systemPrompt = this._baseSystemPrompt;
+		this.rebuildSystemPrompt();
 	}
 
 	private buildExtensionResourcePaths(entries: Array<{ path: string; extensionPath: string }>): Array<{
@@ -2292,7 +2421,7 @@ export class AgentSession {
 
 	private _refreshToolRegistry(options?: { activeToolNames?: string[]; includeAllExtensionTools?: boolean }): void {
 		const previousRegistryNames = new Set(this._toolRegistry.keys());
-		const previousActiveToolNames = this.getActiveToolNames();
+		const previousActiveToolNames = this._configuredActiveToolNames;
 
 		const registeredTools = this._extensionRunner?.getAllRegisteredTools() ?? [];
 		const allCustomTools = [

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -16,6 +16,8 @@ export interface AppKeybindings {
 	"app.exit": true;
 	"app.suspend": true;
 	"app.thinking.cycle": true;
+	"app.plan.toggle": true;
+	"app.edit.toggle": true;
 	"app.model.cycleForward": true;
 	"app.model.cycleBackward": true;
 	"app.model.select": true;
@@ -67,8 +69,16 @@ export const KEYBINDINGS = {
 		description: "Suspend to background",
 	},
 	"app.thinking.cycle": {
-		defaultKeys: "shift+tab",
+		defaultKeys: "alt+t",
 		description: "Cycle thinking level",
+	},
+	"app.plan.toggle": {
+		defaultKeys: "shift+tab",
+		description: "Toggle plan mode",
+	},
+	"app.edit.toggle": {
+		defaultKeys: "ctrl+shift+e",
+		description: "Toggle edit mode",
 	},
 	"app.model.cycleForward": {
 		defaultKeys: "ctrl+p",

--- a/packages/coding-agent/src/core/planning.ts
+++ b/packages/coding-agent/src/core/planning.ts
@@ -1,0 +1,85 @@
+import { join } from "node:path";
+
+export type TurnPlanningMode = "off" | "manual" | "auto";
+
+export interface TurnPlanContext {
+	mode: Exclude<TurnPlanningMode, "off">;
+	path: string;
+	template: string;
+}
+
+function pad(value: number): string {
+	return String(value).padStart(2, "0");
+}
+
+function formatPlanTimestamp(now: Date): string {
+	return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+}
+
+function buildPlanSlug(prompt: string): string {
+	const parts = prompt.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+	const slug = parts.slice(0, 8).join("-").slice(0, 48);
+	return slug || "task";
+}
+
+function buildPlanTitle(prompt: string): string {
+	const compact = prompt.replace(/\s+/g, " ").trim();
+	if (!compact) {
+		return "Execution Plan";
+	}
+	return compact.length <= 72 ? compact : `${compact.slice(0, 69).trimEnd()}...`;
+}
+
+export function buildPlanTemplate(prompt: string): string {
+	return `# ${buildPlanTitle(prompt)}
+
+## Summary
+- Intent: ${prompt.trim()}
+- Outcome: <what should be true when this work is done>
+
+## Success Criteria
+- [ ] <observable outcome 1>
+- [ ] <observable outcome 2>
+
+## Constraints / Notes
+- <repo rules, assumptions, known risks, or things to avoid>
+
+## Affected Areas
+- <files, packages, commands, or flows likely to change>
+
+## Milestones
+- [ ] Milestone 1: <short title>
+  Change: <what will change in this milestone>
+  Validation: <how this milestone will be checked>
+- [ ] Milestone 2: <short title>
+  Change: <what will change in this milestone>
+  Validation: <how this milestone will be checked>
+`;
+}
+
+export function createTurnPlanContext(
+	cwd: string,
+	prompt: string,
+	mode: Exclude<TurnPlanningMode, "off">,
+	now: Date = new Date(),
+): TurnPlanContext {
+	const filename = `${formatPlanTimestamp(now)}-${buildPlanSlug(prompt)}.md`;
+	return {
+		mode,
+		path: join(cwd, ".plans", filename).replace(/\\/g, "/"),
+		template: buildPlanTemplate(prompt),
+	};
+}
+
+export function buildPlanningContextMessage(plan: TurnPlanContext, editMode: boolean): string {
+	return [
+		`Planning is active for this turn (${plan.mode}).`,
+		`Before editing any non-.plans files, write or update this exact plan file: ${plan.path}`,
+		"Do not ask the user for permission to create or update the plan file.",
+		"Fill the template with specific details from the current task instead of leaving placeholders behind.",
+		`After the plan exists, continue execution in the same turn. Repo edits currently require confirmation: ${editMode ? "no" : "yes"}.`,
+		"",
+		"Use this plan template:",
+		plan.template,
+	].join("\n");
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -97,7 +97,8 @@ export interface Settings {
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
-	teamMode?: boolean; // default: false — plan-first execution, pre-mutation approval, worker-per-milestone
+	planMode?: boolean; // default: false — always plan first for each new turn
+	editMode?: boolean; // default: true — allows repo edits without pre-edit confirmation
 	fastModel?: string; // model ID used for scout subagents and meta tasks (e.g. "gpt-5-mini"); defaults to cheapest in-provider model
 }
 
@@ -997,13 +998,23 @@ export class SettingsManager {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
 	}
 
-	getTeamMode(): boolean {
-		return this.settings.teamMode ?? false;
+	getPlanMode(): boolean {
+		return this.settings.planMode ?? false;
 	}
 
-	setTeamMode(enabled: boolean): void {
-		this.globalSettings.teamMode = enabled;
-		this.markModified("teamMode");
+	setPlanMode(enabled: boolean): void {
+		this.globalSettings.planMode = enabled;
+		this.markModified("planMode");
+		this.save();
+	}
+
+	getEditMode(): boolean {
+		return this.settings.editMode ?? true;
+	}
+
+	setEditMode(enabled: boolean): void {
+		this.globalSettings.editMode = enabled;
+		this.markModified("editMode");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -16,6 +16,8 @@ export interface BuiltinSlashCommand {
 
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
+	{ name: "plan", description: "Toggle plan mode, or set explicitly: /plan [on|off]" },
+	{ name: "edit", description: "Toggle edit mode, or set explicitly: /edit [on|off]" },
 	{ name: "model", description: "Select model (opens selector UI)" },
 	{ name: "thinking", description: "Set thinking level or open selector UI" },
 	{ name: "skills", description: "Enable/disable skills for context injection" },
@@ -28,6 +30,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "session", description: "Show session info and stats" },
 	{ name: "changelog", description: "Show changelog entries" },
 	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
+	{ name: "shortcut", description: "Show all keyboard shortcuts" },
 	{ name: "fork", description: "Create a new fork from a previous message" },
 	{ name: "tree", description: "Navigate session tree (switch branches)" },
 	{ name: "login", description: "Login with OAuth provider" },

--- a/packages/coding-agent/src/core/subagents/scheduler.ts
+++ b/packages/coding-agent/src/core/subagents/scheduler.ts
@@ -75,9 +75,9 @@ function buildSingleScoutPlan(prompt: string): SubagentSchedulePlan {
 		tasks: [{ role: "scout", task }],
 		reason: "single_scout",
 		note: [
-			"STOP: Before reading any files, you MUST delegate this task using subagent. Direct file reads will bloat context. Use this call now:",
+			"Optional: if you want to keep the main context cleaner, start with a scout subagent before direct file reads:",
 			JSON.stringify({ role: "scout", task }, null, 2),
-			"Worker roles must not be used in this call. Mutation comes after exploration is complete.",
+			"If the task stays small, continuing locally is fine. Keep worker roles for later execution only.",
 		].join("\n\n"),
 	};
 }
@@ -98,9 +98,9 @@ function buildParallelScoutPlan(prompt: string): SubagentSchedulePlan {
 		tasks,
 		reason: "parallel_scouts",
 		note: [
-			"STOP: Before reading any files, you MUST delegate this task using subagent. Direct file reads will bloat context. Use this call now:",
+			"This task is broad enough that parallel scout sidecars may keep the main context cleaner:",
 			JSON.stringify({ tasks }, null, 2),
-			"If the combined findings are still large, run one planner afterward. Worker roles must not be used in this call. Mutation comes after exploration is complete.",
+			"If the combined findings are still large, run one planner afterward. Keep worker roles for later execution only.",
 		].join("\n\n"),
 	};
 }
@@ -121,9 +121,9 @@ function buildScoutPlannerPlan(prompt: string): SubagentSchedulePlan {
 		tasks,
 		reason: "scout_then_planner",
 		note: [
-			"STOP: Before reading any files, you MUST delegate this task using subagent. Direct file reads will bloat context. Use this call now:",
+			"This task benefits from a scout then planner pass before implementation:",
 			JSON.stringify({ chain: tasks }, null, 2),
-			"After the planner returns, write its output as a plan to .plans/<YYYYMMDD-HHmmss>-<slug>.md in [ ]/[~]/[x]/[!] format before editing any files. Worker roles must not be used in this call. Mutation comes after exploration is complete.",
+			"Use the planner output to keep the next edits focused. Keep worker roles for later execution only.",
 		].join("\n\n"),
 	};
 }
@@ -135,11 +135,15 @@ function buildReviewerPlan(prompt: string): SubagentSchedulePlan {
 		tasks: [{ role: "reviewer", task }],
 		reason: "single_reviewer",
 		note: [
-			"STOP: Before reading any files, you MUST delegate this task using subagent. Direct file reads will bloat context. Use this call now:",
+			"Optional: start with a reviewer sidecar if you want a tighter read-only inspection before diving in:",
 			JSON.stringify({ role: "reviewer", task }, null, 2),
-			"Worker roles must not be used in this call. Mutation comes after exploration is complete.",
+			"Keep worker roles for later execution only.",
 		].join("\n\n"),
 	};
+}
+
+export function shouldAutoPlanForSchedulePlan(plan: SubagentSchedulePlan | undefined): boolean {
+	return plan?.mode === "parallel" || plan?.mode === "chain";
 }
 
 export function buildSubagentSchedulerPlan(input: SubagentSchedulerInput): SubagentSchedulePlan | undefined {

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -8,8 +8,10 @@ import { formatSkillsForPrompt, type Skill } from "./skills.js";
 export interface BuildSystemPromptOptions {
 	/** Custom system prompt (replaces default). */
 	customPrompt?: string;
-	/** Enable team mode: plan-first execution, pre-mutation approval, worker-per-milestone. Default: false. */
-	teamMode?: boolean;
+	/** When true, plan-first execution is enabled for every turn. Default: false. */
+	planMode?: boolean;
+	/** When false, repo edits require confirmation before edit/write. Default: true. */
+	editMode?: boolean;
 	/** When true, inject a strong directive to stop direct file reads and use a subagent instead. */
 	explorationNudge?: boolean;
 	/** Tools to include in prompt. Default: [read, bash, edit, write, search_code, symbols_overview, subagent] */
@@ -34,7 +36,8 @@ export interface BuildSystemPromptOptions {
 export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): string {
 	const {
 		customPrompt,
-		teamMode,
+		planMode,
+		editMode,
 		explorationNudge,
 		selectedTools,
 		toolSnippets,
@@ -168,15 +171,17 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		);
 	}
 	const hasWrite = tools.includes("write") || tools.includes("edit");
-	if (teamMode && hasWrite) {
+	if (editMode === false && hasWrite) {
 		addGuideline(
-			"Before touching any files: use the confirm tool to list the files you plan to create or modify and ask the user to proceed — do not call edit or write until confirmed",
+			"Before editing any non-.plans files: use the confirm tool to list the files you plan to modify and ask the user to proceed — do not call edit or write until confirmed",
+		);
+	}
+	if (planMode && hasWrite) {
+		addGuideline(
+			"When plan mode is on: create or update the provided .plans file before editing repo files, do not ask permission to write that plan file, and continue execution after the plan is written",
 		);
 		addGuideline(
-			"For tasks touching multiple files or requiring multiple steps: write a plan to .plans/<YYYYMMDD-HHmmss>-<slug>.md with milestone steps in [ ] not started / [~] in progress / [x] done / [!] blocked format before editing anything",
-		);
-		addGuideline(
-			"Execute each milestone using a worker subagent — pass the milestone step as the task — so the main context stays clean. Update the plan file after each milestone completes or fails",
+			"The plan must include: title, summary, success criteria, constraints or notes, affected areas, and milestone checklist items using [ ]/[~]/[x]/[!] markers. Each milestone must state both the change and its validation",
 		);
 	}
 	if (hasBash && !hasSearchCode && !hasGrep && !hasFind && !hasLs) {

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -6,6 +6,12 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
+type VisibleBlock =
+	| { type: "text"; text: string }
+	| { type: "thinking"; thinking: string; hasVisibleContentAfter: boolean };
+
+type ContentBlockEntry = { type: "text" | "thinking"; component: Markdown | Text };
+
 /**
  * Component that renders a complete assistant message
  */
@@ -16,6 +22,10 @@ export class AssistantMessageComponent extends Container {
 	private hiddenThinkingLabel: string;
 	private lastMessage?: AssistantMessage;
 	private hasToolCalls = false;
+
+	// Tracks visible (text/thinking) block components for in-place updates during streaming.
+	// Indexed by position in the filtered visible-blocks list.
+	private contentBlockComponents: ContentBlockEntry[] = [];
 
 	constructor(
 		message?: AssistantMessage,
@@ -41,6 +51,7 @@ export class AssistantMessageComponent extends Container {
 	override invalidate(): void {
 		super.invalidate();
 		if (this.lastMessage) {
+			this.contentBlockComponents = [];
 			this.updateContent(this.lastMessage);
 		}
 	}
@@ -48,6 +59,7 @@ export class AssistantMessageComponent extends Container {
 	setHideThinkingBlock(hide: boolean): void {
 		this.hideThinkingBlock = hide;
 		if (this.lastMessage) {
+			this.contentBlockComponents = [];
 			this.updateContent(this.lastMessage);
 		}
 	}
@@ -55,6 +67,7 @@ export class AssistantMessageComponent extends Container {
 	setHiddenThinkingLabel(label: string): void {
 		this.hiddenThinkingLabel = label;
 		if (this.lastMessage) {
+			this.contentBlockComponents = [];
 			this.updateContent(this.lastMessage);
 		}
 	}
@@ -72,70 +85,108 @@ export class AssistantMessageComponent extends Container {
 
 	updateContent(message: AssistantMessage): void {
 		this.lastMessage = message;
+		this.hasToolCalls = message.content.some((c) => c.type === "toolCall");
 
-		// Clear content container
+		const visibleBlocks = this.getVisibleBlocks(message);
+
+		if (!this.tryUpdateInPlace(message, visibleBlocks)) {
+			this.fullRebuild(message, visibleBlocks);
+		}
+	}
+
+	private getVisibleBlocks(message: AssistantMessage): VisibleBlock[] {
+		const result: VisibleBlock[] = [];
+		for (let i = 0; i < message.content.length; i++) {
+			const c = message.content[i];
+			if (c.type === "text" && c.text.trim()) {
+				result.push({ type: "text", text: c.text.trim() });
+			} else if (c.type === "thinking" && c.thinking.trim()) {
+				const hasVisibleContentAfter = message.content
+					.slice(i + 1)
+					.some((d) => (d.type === "text" && d.text.trim()) || (d.type === "thinking" && d.thinking.trim()));
+				result.push({ type: "thinking", thinking: c.thinking.trim(), hasVisibleContentAfter });
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Fast path: when the block structure is unchanged and message is not in an error/abort
+	 * state, update existing Markdown components via setText() rather than destroying and
+	 * recreating the full component tree. This avoids per-token object churn during streaming.
+	 */
+	private tryUpdateInPlace(message: AssistantMessage, visibleBlocks: VisibleBlock[]): boolean {
+		if (message.stopReason === "aborted" || message.stopReason === "error") return false;
+		if (message.errorMessage) return false;
+		if (visibleBlocks.length === 0) return false;
+		if (visibleBlocks.length !== this.contentBlockComponents.length) return false;
+
+		for (let i = 0; i < visibleBlocks.length; i++) {
+			const block = visibleBlocks[i];
+			const cached = this.contentBlockComponents[i];
+			if (block.type !== cached.type) return false;
+			if (block.type === "text" && !(cached.component instanceof Markdown)) return false;
+			if (block.type === "thinking" && !this.hideThinkingBlock && !(cached.component instanceof Markdown))
+				return false;
+			if (block.type === "thinking" && this.hideThinkingBlock && !(cached.component instanceof Text)) return false;
+		}
+
+		for (let i = 0; i < visibleBlocks.length; i++) {
+			const block = visibleBlocks[i];
+			const cached = this.contentBlockComponents[i];
+			if (block.type === "text") {
+				(cached.component as Markdown).setText(block.text);
+			} else if (block.type === "thinking" && !this.hideThinkingBlock) {
+				(cached.component as Markdown).setText(block.thinking);
+			}
+			// hideThinkingBlock: Text component shows a static label, nothing to update
+		}
+		return true;
+	}
+
+	private fullRebuild(message: AssistantMessage, visibleBlocks: VisibleBlock[]): void {
+		this.contentBlockComponents = [];
 		this.contentContainer.clear();
 
-		const hasVisibleContent = message.content.some(
-			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
-		);
-
-		if (hasVisibleContent) {
+		if (visibleBlocks.length > 0) {
 			this.contentContainer.addChild(new Spacer(1));
 		}
 
-		// Render content in order
-		for (let i = 0; i < message.content.length; i++) {
-			const content = message.content[i];
-			if (content.type === "text" && content.text.trim()) {
-				// Assistant text messages with no background - trim the text
-				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, this.markdownTheme));
-			} else if (content.type === "thinking" && content.thinking.trim()) {
-				// Add spacing only when another visible assistant content block follows.
-				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
-				const hasVisibleContentAfter = message.content
-					.slice(i + 1)
-					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
-
+		for (const block of visibleBlocks) {
+			if (block.type === "text") {
+				const md = new Markdown(block.text, 1, 0, this.markdownTheme);
+				this.contentContainer.addChild(md);
+				this.contentBlockComponents.push({ type: "text", component: md });
+			} else if (block.type === "thinking") {
 				if (this.hideThinkingBlock) {
-					// Show static thinking label when hidden
-					this.contentContainer.addChild(
-						new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), 1, 0),
-					);
-					if (hasVisibleContentAfter) {
+					const label = new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), 1, 0);
+					this.contentContainer.addChild(label);
+					this.contentBlockComponents.push({ type: "thinking", component: label });
+					if (block.hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
 					}
 				} else {
-					// Thinking traces in thinkingText color, italic
-					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
-							color: (text: string) => theme.fg("thinkingText", text),
-							italic: true,
-						}),
-					);
-					if (hasVisibleContentAfter) {
+					const md = new Markdown(block.thinking, 1, 0, this.markdownTheme, {
+						color: (text: string) => theme.fg("thinkingText", text),
+						italic: true,
+					});
+					this.contentContainer.addChild(md);
+					this.contentBlockComponents.push({ type: "thinking", component: md });
+					if (block.hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
 					}
 				}
 			}
 		}
 
-		// Check if aborted - show after partial content
-		// But only if there are no tool calls (tool execution components will show the error)
-		const hasToolCalls = message.content.some((c) => c.type === "toolCall");
-		this.hasToolCalls = hasToolCalls;
-		if (!hasToolCalls) {
+		// Error/abort state — only when there are no tool calls
+		if (!this.hasToolCalls) {
 			if (message.stopReason === "aborted") {
 				const abortMessage =
 					message.errorMessage && message.errorMessage !== "Request was aborted"
 						? message.errorMessage
 						: "Operation aborted";
-				if (hasVisibleContent) {
-					this.contentContainer.addChild(new Spacer(1));
-				} else {
-					this.contentContainer.addChild(new Spacer(1));
-				}
+				this.contentContainer.addChild(new Spacer(1));
 				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), 1, 0));
 			} else if (message.stopReason === "error") {
 				const errorMsg = message.errorMessage || "Unknown error";

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -30,6 +30,8 @@ const THINKING_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 
 export interface SettingsConfig {
 	autoCompact: boolean;
+	planMode: boolean;
+	editMode: boolean;
 	showImages: boolean;
 	autoResizeImages: boolean;
 	blockImages: boolean;
@@ -55,6 +57,8 @@ export interface SettingsConfig {
 
 export interface SettingsCallbacks {
 	onAutoCompactChange: (enabled: boolean) => void;
+	onPlanModeChange: (enabled: boolean) => void;
+	onEditModeChange: (enabled: boolean) => void;
 	onShowImagesChange: (enabled: boolean) => void;
 	onAutoResizeImagesChange: (enabled: boolean) => void;
 	onBlockImagesChange: (blocked: boolean) => void;
@@ -162,6 +166,20 @@ export class SettingsSelectorComponent extends Container {
 				label: "Auto-compact",
 				description: "Automatically compact context when it gets too large",
 				currentValue: config.autoCompact ? "true" : "false",
+				values: ["true", "false"],
+			},
+			{
+				id: "plan-mode",
+				label: "Plan mode",
+				description: "Always create or update a .plans file before repo edits",
+				currentValue: config.planMode ? "true" : "false",
+				values: ["true", "false"],
+			},
+			{
+				id: "edit-mode",
+				label: "Edit mode",
+				description: "Allow repo edits without pre-edit confirmation",
+				currentValue: config.editMode ? "true" : "false",
 				values: ["true", "false"],
 			},
 			{
@@ -374,6 +392,12 @@ export class SettingsSelectorComponent extends Container {
 				switch (id) {
 					case "autocompact":
 						callbacks.onAutoCompactChange(newValue === "true");
+						break;
+					case "plan-mode":
+						callbacks.onPlanModeChange(newValue === "true");
+						break;
+					case "edit-mode":
+						callbacks.onEditModeChange(newValue === "true");
 						break;
 					case "show-images":
 						callbacks.onShowImagesChange(newValue === "true");

--- a/packages/coding-agent/src/modes/interactive/components/shell-sidebar.ts
+++ b/packages/coding-agent/src/modes/interactive/components/shell-sidebar.ts
@@ -264,6 +264,13 @@ export class ShellSidebarComponent implements Component {
 		const thinkingValue = model?.reasoning ? thinkingLevel : "unsupported";
 		headerGroup.push(blank);
 		headerGroup.push(...labeledSection("Thinking", theme.fg(thinkingTone, thinkingValue)));
+		const planMode = this.session.planningModeStatus;
+		const planTone = planMode === "manual" ? "accent" : planMode === "auto" ? "borderAccent" : "muted";
+		headerGroup.push(blank);
+		headerGroup.push(...labeledSection("Plan", theme.fg(planTone, planMode)));
+		const editMode = this.session.editModeEnabled ? "on" : "off";
+		headerGroup.push(blank);
+		headerGroup.push(...labeledSection("Edit", theme.fg(editMode === "on" ? "success" : "warning", editMode)));
 		topGroups.push(headerGroup);
 
 		let totalInput = 0;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2008,7 +2008,9 @@ export class InteractiveMode {
 		this.applyRuntimeSettings();
 		await this.bindCurrentSessionExtensions();
 		this.subscribeToAgent();
-		await this.updateAvailableProviderCount();
+		// Fire provider count refresh in the background — it makes network calls to check
+		// model visibility adapters and must not block the UI from responding.
+		void this.updateAvailableProviderCount().then(() => this.ui.requestRender());
 		this.updateEditorBorderColor();
 		this.updateTerminalTitle();
 	}
@@ -2741,6 +2743,11 @@ export class InteractiveMode {
 		// so they work correctly regardless of which editor is active
 		this.defaultEditor.onEscape = () => {
 			if (this.loadingAnimation) {
+				// Stop the spinner immediately — agent_end will clean up the rest.
+				this.loadingAnimation.stop();
+				this.loadingAnimation = undefined;
+				this.statusContainer.clear();
+				this.ui.requestRender();
 				this.restoreQueuedMessagesToEditor({ abort: true });
 			} else if (this.session.isBashRunning) {
 				this.session.abortBash();
@@ -2772,6 +2779,8 @@ export class InteractiveMode {
 		this.defaultEditor.onCtrlD = () => this.handleCtrlD();
 		this.defaultEditor.onAction("app.suspend", () => this.handleCtrlZ());
 		this.defaultEditor.onAction("app.thinking.cycle", () => this.cycleThinkingLevel());
+		this.defaultEditor.onAction("app.plan.toggle", () => this.setPlanMode(!this.settingsManager.getPlanMode()));
+		this.defaultEditor.onAction("app.edit.toggle", () => this.setEditMode(!this.settingsManager.getEditMode()));
 		this.defaultEditor.onAction("app.model.cycleForward", () => this.cycleModel("forward"));
 		this.defaultEditor.onAction("app.model.cycleBackward", () => this.cycleModel("backward"));
 
@@ -2836,6 +2845,18 @@ export class InteractiveMode {
 			if (text === "/settings") {
 				this.showSettingsSelector();
 				this.editor.setText("");
+				return;
+			}
+			if (text === "/plan" || text.startsWith("/plan ")) {
+				const value = text.startsWith("/plan ") ? text.slice(6).trim() : undefined;
+				this.editor.setText("");
+				this.handlePlanCommand(value);
+				return;
+			}
+			if (text === "/edit" || text.startsWith("/edit ")) {
+				const value = text.startsWith("/edit ") ? text.slice(6).trim() : undefined;
+				this.editor.setText("");
+				this.handleEditCommand(value);
 				return;
 			}
 			if (text === "/scoped-models") {
@@ -2908,7 +2929,7 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/hotkeys") {
+			if (text === "/hotkeys" || text === "/shortcut") {
 				this.handleHotkeysCommand();
 				this.editor.setText("");
 				return;
@@ -4136,6 +4157,8 @@ export class InteractiveMode {
 			const selector = new SettingsSelectorComponent(
 				{
 					autoCompact: this.session.autoCompactionEnabled,
+					planMode: this.settingsManager.getPlanMode(),
+					editMode: this.settingsManager.getEditMode(),
 					showImages: this.settingsManager.getShowImages(),
 					autoResizeImages: this.settingsManager.getImageAutoResize(),
 					blockImages: this.settingsManager.getBlockImages(),
@@ -4162,6 +4185,12 @@ export class InteractiveMode {
 					onAutoCompactChange: (enabled) => {
 						this.session.setAutoCompactionEnabled(enabled);
 						this.footer.setAutoCompactEnabled(enabled);
+					},
+					onPlanModeChange: (enabled) => {
+						this.setPlanMode(enabled);
+					},
+					onEditModeChange: (enabled) => {
+						this.setEditMode(enabled);
 					},
 					onShowImagesChange: (enabled) => {
 						this.settingsManager.setShowImages(enabled);
@@ -4267,6 +4296,46 @@ export class InteractiveMode {
 			);
 			return { component: selector, focus: selector.getSettingsList() };
 		});
+	}
+
+	private setPlanMode(enabled: boolean): void {
+		this.settingsManager.setPlanMode(enabled);
+		this.session.rebuildSystemPrompt();
+		this.ui.requestRender();
+		this.showStatus(`Plan mode: ${enabled ? "on" : "off"}`);
+	}
+
+	private setEditMode(enabled: boolean): void {
+		this.settingsManager.setEditMode(enabled);
+		this.session.rebuildSystemPrompt();
+		this.ui.requestRender();
+		this.showStatus(`Edit mode: ${enabled ? "on" : "off"}`);
+	}
+
+	private handlePlanCommand(value?: string): void {
+		const normalized = value?.toLowerCase();
+		if (normalized === undefined || normalized === "") {
+			this.setPlanMode(!this.settingsManager.getPlanMode());
+			return;
+		}
+		if (normalized !== "on" && normalized !== "off") {
+			this.showError("Usage: /plan [on|off]");
+			return;
+		}
+		this.setPlanMode(normalized === "on");
+	}
+
+	private handleEditCommand(value?: string): void {
+		const normalized = value?.toLowerCase();
+		if (normalized === undefined || normalized === "") {
+			this.setEditMode(!this.settingsManager.getEditMode());
+			return;
+		}
+		if (normalized !== "on" && normalized !== "off") {
+			this.showError("Usage: /edit [on|off]");
+			return;
+		}
+		this.setEditMode(normalized === "on");
 	}
 
 	private handleThinkingCommand(levelText?: string): void {
@@ -5428,6 +5497,8 @@ export class InteractiveMode {
 		const exit = this.getAppKeyDisplay("app.exit");
 		const suspend = this.getAppKeyDisplay("app.suspend");
 		const cycleThinkingLevel = this.getAppKeyDisplay("app.thinking.cycle");
+		const togglePlanMode = this.getAppKeyDisplay("app.plan.toggle");
+		const toggleEditMode = this.getAppKeyDisplay("app.edit.toggle");
 		const cycleModelForward = this.getAppKeyDisplay("app.model.cycleForward");
 		const selectModel = this.getAppKeyDisplay("app.model.select");
 		const expandTools = this.getAppKeyDisplay("app.tools.expand");
@@ -5472,6 +5543,8 @@ export class InteractiveMode {
 | \`${exit}\` | Exit (when editor is empty) |
 | \`${suspend}\` | Suspend to background |
 | \`${cycleThinkingLevel}\` | Cycle thinking level |
+| \`${togglePlanMode}\` | Toggle plan mode |
+| \`${toggleEditMode}\` | Toggle edit mode |
 | \`${cycleModelForward}\` / \`${cycleModelBackward}\` | Cycle models |
 | \`${selectModel}\` | Open model selector |
 | \`${expandTools}\` | Toggle tool output expansion |

--- a/packages/coding-agent/test/interactive-mode-plan-edit.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-edit.test.ts
@@ -1,0 +1,114 @@
+import { Container } from "@mariozechner/pi-tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.js";
+import { getMarkdownTheme, initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function renderAll(container: Container, width = 220): string {
+	return container.children
+		.flatMap((child) => child.render(width))
+		.join("\n")
+		.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+describe("InteractiveMode plan/edit controls", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("setPlanMode persists the flag, rebuilds the prompt, and shows status", () => {
+		const fakeThis: any = {
+			settingsManager: { setPlanMode: vi.fn() },
+			session: { rebuildSystemPrompt: vi.fn() },
+			ui: { requestRender: vi.fn() },
+			showStatus: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.setPlanMode.call(fakeThis, true);
+
+		expect(fakeThis.settingsManager.setPlanMode).toHaveBeenCalledWith(true);
+		expect(fakeThis.session.rebuildSystemPrompt).toHaveBeenCalledTimes(1);
+		expect(fakeThis.ui.requestRender).toHaveBeenCalledTimes(1);
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("Plan mode: on");
+	});
+
+	test("setEditMode persists the flag, rebuilds the prompt, and shows status", () => {
+		const fakeThis: any = {
+			settingsManager: { setEditMode: vi.fn() },
+			session: { rebuildSystemPrompt: vi.fn() },
+			ui: { requestRender: vi.fn() },
+			showStatus: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.setEditMode.call(fakeThis, false);
+
+		expect(fakeThis.settingsManager.setEditMode).toHaveBeenCalledWith(false);
+		expect(fakeThis.session.rebuildSystemPrompt).toHaveBeenCalledTimes(1);
+		expect(fakeThis.ui.requestRender).toHaveBeenCalledTimes(1);
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("Edit mode: off");
+	});
+
+	test("/plan and /edit commands dispatch the parsed on/off state", () => {
+		const fakeThis: any = {
+			setPlanMode: vi.fn(),
+			setEditMode: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.handlePlanCommand.call(fakeThis, "on");
+		(InteractiveMode as any).prototype.handleEditCommand.call(fakeThis, "off");
+
+		expect(fakeThis.setPlanMode).toHaveBeenCalledWith(true);
+		expect(fakeThis.setEditMode).toHaveBeenCalledWith(false);
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
+	test("/plan and /edit toggle when called without args", () => {
+		const fakeThis: any = {
+			settingsManager: { getPlanMode: vi.fn().mockReturnValue(false), getEditMode: vi.fn().mockReturnValue(true) },
+			setPlanMode: vi.fn(),
+			setEditMode: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.handlePlanCommand.call(fakeThis, undefined);
+		(InteractiveMode as any).prototype.handleEditCommand.call(fakeThis, "");
+
+		expect(fakeThis.setPlanMode).toHaveBeenCalledWith(true);
+		expect(fakeThis.setEditMode).toHaveBeenCalledWith(false);
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
+	test("/plan and /edit commands show usage for invalid values", () => {
+		const fakeThis: any = {
+			settingsManager: { getPlanMode: vi.fn(), getEditMode: vi.fn() },
+			setPlanMode: vi.fn(),
+			setEditMode: vi.fn(),
+			showError: vi.fn(),
+		};
+
+		(InteractiveMode as any).prototype.handlePlanCommand.call(fakeThis, "maybe");
+		(InteractiveMode as any).prototype.handleEditCommand.call(fakeThis, "yes");
+
+		expect(fakeThis.showError).toHaveBeenCalledWith("Usage: /plan [on|off]");
+		expect(fakeThis.showError).toHaveBeenCalledWith("Usage: /edit [on|off]");
+		expect(fakeThis.setPlanMode).not.toHaveBeenCalled();
+		expect(fakeThis.setEditMode).not.toHaveBeenCalled();
+	});
+
+	test("/hotkeys and /shortcut include plan and edit toggles", () => {
+		const fakeThis: any = {
+			chatContainer: new Container(),
+			session: { extensionRunner: undefined },
+			ui: { requestRender: vi.fn() },
+			getMarkdownThemeWithSettings: () => getMarkdownTheme(),
+			getAppKeyDisplay: (action: string) => action,
+			getEditorKeyDisplay: (action: string) => action,
+		};
+
+		(InteractiveMode as any).prototype.handleHotkeysCommand.call(fakeThis);
+
+		const rendered = renderAll(fakeThis.chatContainer);
+		expect(rendered).toContain("Toggle plan mode");
+		expect(rendered).toContain("Toggle edit mode");
+	});
+});

--- a/packages/coding-agent/test/keybindings-migration.test.ts
+++ b/packages/coding-agent/test/keybindings-migration.test.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.js";
-import { KeybindingsManager } from "../src/core/keybindings.js";
+import { KEYBINDINGS, KeybindingsManager } from "../src/core/keybindings.js";
 import { runMigrations } from "../src/migrations.js";
 
 describe("keybindings migration", () => {
@@ -84,5 +84,10 @@ describe("keybindings migration", () => {
 		const effective = keybindings.getEffectiveConfig();
 		expect(effective["tui.select.confirm"]).toBe("enter");
 		expect(effective["app.interrupt"]).toBe("ctrl+x");
+	});
+
+	it("defines default keybindings for plan and edit toggles", () => {
+		expect(KEYBINDINGS["app.plan.toggle"].defaultKeys).toBe("shift+tab");
+		expect(KEYBINDINGS["app.edit.toggle"].defaultKeys).toBe("ctrl+shift+e");
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -107,6 +107,34 @@ describe("SettingsManager", () => {
 			const savedSettings = JSON.parse(readFileSync(settingsPath, "utf-8"));
 			expect(savedSettings.defaultThinkingLevel).toBe("high");
 		});
+
+		it("should persist planMode and editMode while preserving unrelated settings", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(
+				settingsPath,
+				JSON.stringify({
+					theme: "dark",
+					defaultModel: "claude-sonnet",
+				}),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			const currentSettings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			currentSettings.enabledModels = ["claude-opus-4-5"];
+			writeFileSync(settingsPath, JSON.stringify(currentSettings, null, 2));
+
+			manager.setPlanMode(true);
+			manager.setEditMode(false);
+			await manager.flush();
+
+			const savedSettings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(savedSettings.planMode).toBe(true);
+			expect(savedSettings.editMode).toBe(false);
+			expect(savedSettings.theme).toBe("dark");
+			expect(savedSettings.defaultModel).toBe("claude-sonnet");
+			expect(savedSettings.enabledModels).toEqual(["claude-opus-4-5"]);
+		});
 	});
 
 	describe("packages migration", () => {

--- a/packages/coding-agent/test/shell-sidebar-mode-state.test.ts
+++ b/packages/coding-agent/test/shell-sidebar-mode-state.test.ts
@@ -1,0 +1,80 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.js";
+import type { ReadonlyFooterDataProvider } from "../src/core/footer-data-provider.js";
+import { ShellSidebarComponent } from "../src/modes/interactive/components/shell-sidebar.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function createSession(options?: { plan?: "off" | "auto" | "manual"; edit?: boolean }): AgentSession {
+	return {
+		model: {
+			id: "claude-sonnet-4.6",
+			provider: "github-copilot",
+			contextWindow: 1_000_000,
+			reasoning: true,
+		},
+		thinkingLevel: "medium",
+		planningModeStatus: options?.plan ?? "off",
+		editModeEnabled: options?.edit ?? true,
+		sessionManager: {
+			getEntries: () => [
+				{
+					type: "message",
+					message: {
+						role: "user",
+						content: [{ type: "text", text: "Investigate mode state rendering" }],
+					},
+				},
+			],
+			getSessionName: () => undefined,
+			getCwd: () => "/Users/test/project",
+		},
+		getContextUsage: () => ({ tokens: 123_000, contextWindow: 1_000_000, percent: 12.3 }),
+	} as unknown as AgentSession;
+}
+
+function createFooterData(): ReadonlyFooterDataProvider {
+	return {
+		getGitBranch: () => "main",
+		getExtensionStatuses: () => new Map<string, string>(),
+		getAvailableProviderCount: () => 2,
+		onBranchChange: () => () => {},
+	};
+}
+
+function stripAnsi(value: string): string {
+	return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+describe("ShellSidebarComponent mode state", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("renders default off/on mode state", () => {
+		const sidebar = new ShellSidebarComponent(createSession(), createFooterData());
+		sidebar.setHeight(24);
+
+		const rendered = stripAnsi(sidebar.render(30).join("\n"));
+		expect(rendered).toContain("Plan");
+		expect(rendered).toContain("off");
+		expect(rendered).toContain("Edit");
+		expect(rendered).toContain("on");
+	});
+
+	test("renders manual and auto planning state labels", () => {
+		const manualSidebar = new ShellSidebarComponent(
+			createSession({ plan: "manual", edit: false }),
+			createFooterData(),
+		);
+		manualSidebar.setHeight(24);
+		const manualRendered = stripAnsi(manualSidebar.render(30).join("\n"));
+		expect(manualRendered).toContain("manual");
+		expect(manualRendered).toContain("off");
+
+		const autoSidebar = new ShellSidebarComponent(createSession({ plan: "auto", edit: true }), createFooterData());
+		autoSidebar.setHeight(24);
+		const autoRendered = stripAnsi(autoSidebar.render(30).join("\n"));
+		expect(autoRendered).toContain("auto");
+		expect(autoRendered).toContain("on");
+	});
+});

--- a/packages/coding-agent/test/subagent-scheduler.test.ts
+++ b/packages/coding-agent/test/subagent-scheduler.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fauxAssistantMessage } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildSubagentSchedulerPlan } from "../src/core/subagents/scheduler.js";
+import { buildSubagentSchedulerPlan, shouldAutoPlanForSchedulePlan } from "../src/core/subagents/scheduler.js";
 import { createHarness, getUserTexts } from "./suite/harness.js";
 
 describe("subagent scheduler", () => {
@@ -15,6 +15,7 @@ describe("subagent scheduler", () => {
 		});
 
 		expect(plan?.mode).toBe("parallel");
+		expect(shouldAutoPlanForSchedulePlan(plan)).toBe(true);
 		expect(plan?.tasks).toHaveLength(2);
 		expect(plan?.tasks.every((task) => task.role === "scout")).toBe(true);
 	});
@@ -29,6 +30,7 @@ describe("subagent scheduler", () => {
 		});
 
 		expect(plan?.mode).toBe("chain");
+		expect(shouldAutoPlanForSchedulePlan(plan)).toBe(true);
 		expect(plan?.tasks.map((task) => task.role)).toEqual(["scout", "planner"]);
 		expect(plan?.note).toContain("{previous}");
 	});
@@ -42,6 +44,7 @@ describe("subagent scheduler", () => {
 		});
 
 		expect(plan).toBeUndefined();
+		expect(shouldAutoPlanForSchedulePlan(plan)).toBe(false);
 	});
 
 	it("never auto-spawns a worker", () => {
@@ -116,6 +119,15 @@ describe("subagent scheduler prompt injection", () => {
 					message.role === "custom" && message.customType === "subagent_scheduler" && message.display === false,
 			),
 		).toBe(true);
+		expect(
+			harness.session.messages.some(
+				(message) =>
+					message.role === "custom" &&
+					message.customType === "planning_context" &&
+					message.display === false &&
+					(message.details as { mode?: string } | undefined)?.mode === "auto",
+			),
+		).toBe(true);
 	});
 
 	it("does not inject a scheduler message for a simple direct task", async () => {
@@ -131,6 +143,11 @@ describe("subagent scheduler prompt injection", () => {
 		expect(
 			harness.session.messages.some(
 				(message) => message.role === "custom" && message.customType === "subagent_scheduler",
+			),
+		).toBe(false);
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "planning_context",
 			),
 		).toBe(false);
 	});

--- a/packages/coding-agent/test/suite/agent-session-mode-gating.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-mode-gating.test.ts
@@ -1,0 +1,103 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall } from "@mariozechner/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getAssistantTexts, getMessageText, type Harness } from "./harness.js";
+
+function getLastToolResultText(harness: Harness): string {
+	const toolResults = harness.session.messages.filter((message) => message.role === "toolResult");
+	const toolResult = toolResults[toolResults.length - 1];
+	return toolResult ? getMessageText(toolResult) : "";
+}
+
+describe("AgentSession plan/edit modes", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("blocks repo writes when edit mode is off and no confirm was given", async () => {
+		const harness = await createHarness({ settings: { editMode: false } });
+		harnesses.push(harness);
+		const targetPath = join(harness.tempDir, "blocked.txt");
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("write", { path: targetPath, content: "blocked" })], {
+				stopReason: "toolUse",
+			}),
+			() => fauxAssistantMessage(getLastToolResultText(harness)),
+		]);
+
+		await harness.session.prompt("Write the file");
+
+		expect(getAssistantTexts(harness)).toContain(
+			"Edit mode is off. Use the confirm tool to ask for permission before editing files outside .plans.",
+		);
+		expect(existsSync(targetPath)).toBe(false);
+	});
+
+	it("allows confirm then write in one turn and resets approval on the next turn", async () => {
+		const harness = await createHarness({ settings: { editMode: false } });
+		harnesses.push(harness);
+		const approvedPath = join(harness.tempDir, "approved.txt");
+		const blockedPath = join(harness.tempDir, "blocked-again.txt");
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("confirm", { message: "Proceed?" })], { stopReason: "toolUse" }),
+			() =>
+				fauxAssistantMessage([fauxToolCall("write", { path: approvedPath, content: "approved" })], {
+					stopReason: "toolUse",
+				}),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("Write the approved file");
+
+		expect(existsSync(approvedPath)).toBe(true);
+		expect(readFileSync(approvedPath, "utf-8")).toBe("approved");
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("write", { path: blockedPath, content: "blocked again" })], {
+				stopReason: "toolUse",
+			}),
+			() => fauxAssistantMessage(getLastToolResultText(harness)),
+		]);
+
+		await harness.session.prompt("Write another file");
+
+		expect(existsSync(blockedPath)).toBe(false);
+		expect(getAssistantTexts(harness)).toContain(
+			"Edit mode is off. Use the confirm tool to ask for permission before editing files outside .plans.",
+		);
+	});
+
+	it("allows .plans writes while planning is active even when edit mode is off", async () => {
+		const harness = await createHarness({ settings: { planMode: true, editMode: false } });
+		harnesses.push(harness);
+		const planPath = join(harness.tempDir, ".plans", "manual-plan.md");
+
+		harness.setResponses([
+			fauxAssistantMessage([fauxToolCall("write", { path: ".plans/manual-plan.md", content: "# Plan" })], {
+				stopReason: "toolUse",
+			}),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("Make a broad multi-file change");
+
+		expect(
+			harness.session.messages.some(
+				(message) =>
+					message.role === "custom" &&
+					message.customType === "planning_context" &&
+					message.display === false &&
+					(message.details as { mode?: string } | undefined)?.mode === "manual",
+			),
+		).toBe(true);
+		expect(existsSync(planPath)).toBe(true);
+		expect(readFileSync(planPath, "utf-8")).toBe("# Plan");
+	});
+});

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -106,9 +106,61 @@ describe("buildSystemPrompt", () => {
 			});
 
 			expect(prompt).toContain("Use search_code for keyword, regex, filename, or AST discovery before bash");
-			expect(prompt).toContain("Use symbols_overview before opening large files or folders");
-			expect(prompt).toContain("Use read only on the most relevant files after search_code and symbols_overview");
+			expect(prompt).toContain("For files over ~300 lines, use symbols_overview before paging through with read");
+			expect(prompt).toContain(
+				"Use read with paths[] to read multiple files in one call; use it only on the most relevant files after search_code and symbols_overview",
+			);
 			expect(prompt).toContain("Use subagent when code work splits cleanly into bounded side tasks");
+		});
+
+		test("shows plan instructions only when plan mode is enabled", () => {
+			const withPlanMode = buildSystemPrompt({
+				selectedTools: ["edit", "write"],
+				planMode: true,
+				contextFiles: [],
+				skills: [],
+			});
+			const withoutPlanMode = buildSystemPrompt({
+				selectedTools: ["edit", "write"],
+				planMode: false,
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(withPlanMode).toContain("When plan mode is on");
+			expect(withPlanMode).toContain("milestone checklist items using [ ]/[~]/[x]/[!]");
+			expect(withoutPlanMode).not.toContain("When plan mode is on");
+		});
+
+		test("shows edit confirmation instructions only when edit mode is disabled", () => {
+			const withEditGate = buildSystemPrompt({
+				selectedTools: ["edit", "write", "confirm"],
+				editMode: false,
+				contextFiles: [],
+				skills: [],
+			});
+			const withoutEditGate = buildSystemPrompt({
+				selectedTools: ["edit", "write", "confirm"],
+				editMode: true,
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(withEditGate).toContain("Before editing any non-.plans files");
+			expect(withoutEditGate).not.toContain("Before editing any non-.plans files");
+		});
+
+		test("drops the old worker-per-milestone team mode wording", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: ["edit", "write"],
+				planMode: true,
+				editMode: false,
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).not.toContain("Execute each milestone using a worker subagent");
+			expect(prompt).not.toContain("worker-per-milestone");
 		});
 	});
 });


### PR DESCRIPTION
Plan/Edit Mode System
---------------------
New planning.ts module introduces TurnPlanningMode ("off" | "manual" | "auto") and TurnPlanContext. When planning is active, a structured .plans/<timestamp>-<slug>.md file is injected as a context message before the turn, with a fully templated scaffold (summary, success criteria, constraints, affected areas, milestones with change + validation fields).

Planning activates in two ways:
- manual: user toggles /plan on or presses shift+tab
- auto: scheduler detects a parallel or chain subagent plan (shouldAutoPlanForSchedulePlan)

Edit Mode (default: on) controls whether repo mutations require pre-approval:
- editMode=true (default): edit/write proceed freely
- editMode=false: beforeToolCall blocks edit/write and asks the agent to call confirm first; _turnEditApprovalGranted is set when confirm returns "confirmed"

settings-manager: teamMode renamed to planMode; editMode added (default: true).
system-prompt: guidelines updated to match new planMode/editMode semantics.
settings-selector: plan mode and edit mode toggles added to /settings UI.
shell-sidebar: Plan (off/auto/manual) and Edit (on/off) status shown in the sidebar.

Keybindings
-----------
- app.plan.toggle: shift+tab (was app.thinking.cycle)
- app.edit.toggle: ctrl+shift+e (new)
- app.thinking.cycle: moved to alt+t

Slash Commands
--------------
/plan [on|off], /edit [on|off], /shortcut added.

Scheduler Notes Softened
------------------------
Scheduler hint wording changed from "STOP: you MUST delegate" to softer "Optional:" language so the agent is guided rather than blocked from local reads when appropriate.

UI Performance
--------------
assistant-message: updateContent() now does an in-place fast path during streaming. When block structure is unchanged (text/thinking count and types match), existing Markdown components are updated via setText() instead of destroying and recreating the full child tree on every token. Full rebuild only on structure change or abort/error. Eliminates per-token object allocation and render-cache churn for long responses.

interactive-mode: Pressing Escape while the agent is working now immediately stops and clears the loading spinner before signalling abort. Previously the spinner kept running until the API acknowledged the abort (up to several seconds).

interactive-mode: handleRuntimeSessionChange() no longer awaits updateAvailableProviderCount(). The provider count refresh makes network calls to each model visibility adapter and was blocking /new and session switches. It now runs in the background and triggers a render when done.