### PR TITLE
Upstream proposal: skip identical partial TUI renders

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -216,6 +216,16 @@ export class Container implements Component {
  */
 export class TUI extends Container {
 	public terminal: Terminal;
+	private lastDiffSignature:
+		| {
+				viewportTop: number;
+				firstChanged: number;
+				renderEnd: number;
+				newLength: number;
+				previousLength: number;
+				content: string;
+		  }
+		| undefined;
 	private previousLines: string[] = [];
 	private previousWidth = 0;
 	private previousHeight = 0;
@@ -916,6 +926,7 @@ export class TUI extends Container {
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
+			this.lastDiffSignature = undefined;
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
@@ -1097,6 +1108,30 @@ export class TUI extends Container {
 		// Only render changed lines (firstChanged to lastChanged), not all lines to end
 		// This reduces flicker when only a single line changes (e.g., spinner animation)
 		const renderEnd = Math.min(lastChanged, newLines.length - 1);
+		const diffSignature = {
+			viewportTop: prevViewportTop,
+			firstChanged,
+			renderEnd,
+			newLength: newLines.length,
+			previousLength: this.previousLines.length,
+			content: newLines.slice(firstChanged, renderEnd + 1).join("\n"),
+		};
+		if (
+			this.lastDiffSignature &&
+			this.lastDiffSignature.viewportTop === diffSignature.viewportTop &&
+			this.lastDiffSignature.firstChanged === diffSignature.firstChanged &&
+			this.lastDiffSignature.renderEnd === diffSignature.renderEnd &&
+			this.lastDiffSignature.newLength === diffSignature.newLength &&
+			this.lastDiffSignature.previousLength === diffSignature.previousLength &&
+			this.lastDiffSignature.content === diffSignature.content
+		) {
+			this.positionHardwareCursor(cursorPos, newLines.length);
+			this.previousLines = newLines;
+			this.previousWidth = width;
+			this.previousHeight = height;
+			this.previousViewportTop = prevViewportTop;
+			return;
+		}
 		for (let i = firstChanged; i <= renderEnd; i++) {
 			if (i > firstChanged) buffer += "\r\n";
 			buffer += "\x1b[2K"; // Clear current line
@@ -1198,6 +1233,7 @@ export class TUI extends Container {
 		// Position hardware cursor for IME
 		this.positionHardwareCursor(cursorPos, newLines.length);
 
+		this.lastDiffSignature = diffSignature;
 		this.previousLines = newLines;
 		this.previousWidth = width;
 		this.previousHeight = height;

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -281,6 +281,35 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 
+	it("skips writing identical partial render diffs", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const previousLines = ["Header", "Working old", "Footer"];
+		component.lines = previousLines;
+		tui.start();
+		await terminal.waitForRender();
+		const previousRenderedLines = [...(tui as unknown as { previousLines: string[] }).previousLines];
+
+		component.lines = ["Header", "Working new", "Footer"];
+		tui.requestRender();
+		await terminal.waitForRender();
+		const firstPartialWrite = terminal.getWrites();
+		assert.ok(firstPartialWrite.includes("Working new"), "First partial render should update the changed line");
+
+		terminal.clearWrites();
+		(tui as unknown as { previousLines: string[] }).previousLines = previousRenderedLines;
+
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(terminal.getWrites(), "", "Identical partial render should not write to the terminal");
+
+		tui.stop();
+	});
+
 	it("resets styles after each rendered line", async () => {
 		const terminal = new VirtualTerminal(20, 6);
 		const tui = new TUI(terminal);


### PR DESCRIPTION
## Summary

- track the last partial render diff signature in the TUI renderer
- skip terminal writes when the next partial diff is identical
- reset the signature on full redraws and cover the behavior with a focused regression test

## Validation

- node --test --import tsx test/tui-render.test.ts
- bun run check

Piper review issue: #12