### PR TITLE
Upstream proposal: add resize-safe TUI viewport

### DIFF
--- a/packages/tui/src/components/viewport.ts
+++ b/packages/tui/src/components/viewport.ts
@@ -1,0 +1,108 @@
+import type { Component } from "../tui.js";
+
+export type ViewportAnchor = "top" | "bottom";
+
+/**
+ * Clips a child component to a fixed number of lines and pads to that height.
+ * The scroll offset is interpreted from the top or bottom depending on anchor.
+ */
+export class Viewport implements Component {
+	private height = 0;
+	private scrollOffset = 0;
+	private anchor: ViewportAnchor;
+	private lastContentHeight = 0;
+	private lastViewportHeight = 0;
+	private lastRenderWidth = 0;
+
+	constructor(
+		private child: Component,
+		options?: {
+			height?: number;
+			scrollOffset?: number;
+			anchor?: ViewportAnchor;
+		},
+	) {
+		this.height = Math.max(0, options?.height ?? 0);
+		this.scrollOffset = Math.max(0, options?.scrollOffset ?? 0);
+		this.anchor = options?.anchor ?? "top";
+	}
+
+	setChild(child: Component): void {
+		this.child = child;
+	}
+
+	setHeight(height: number): void {
+		this.height = Math.max(0, height);
+	}
+
+	getHeight(): number {
+		return this.height;
+	}
+
+	setScrollOffset(scrollOffset: number): void {
+		this.scrollOffset = Math.max(0, scrollOffset);
+	}
+
+	getScrollOffset(): number {
+		return this.scrollOffset;
+	}
+
+	setAnchor(anchor: ViewportAnchor): void {
+		this.anchor = anchor;
+	}
+
+	getAnchor(): ViewportAnchor {
+		return this.anchor;
+	}
+
+	getContentHeight(): number {
+		return this.lastContentHeight;
+	}
+
+	getMaxScrollOffset(): number {
+		return Math.max(0, this.lastContentHeight - this.lastViewportHeight);
+	}
+
+	invalidate(): void {
+		this.child.invalidate?.();
+	}
+
+	render(width: number): string[] {
+		const viewportHeight = Math.max(0, this.height);
+		if (viewportHeight === 0) {
+			this.lastContentHeight = 0;
+			this.lastViewportHeight = 0;
+			this.lastRenderWidth = width;
+			return [];
+		}
+
+		if (
+			(this.lastRenderWidth !== 0 && this.lastRenderWidth !== width) ||
+			(this.lastViewportHeight !== 0 && this.lastViewportHeight !== viewportHeight)
+		) {
+			this.lastContentHeight = 0;
+			this.lastViewportHeight = 0;
+		}
+
+		const lines = this.child.render(width);
+		this.lastRenderWidth = width;
+		this.lastContentHeight = lines.length;
+		this.lastViewportHeight = viewportHeight;
+
+		const maxScrollOffset = Math.max(0, lines.length - viewportHeight);
+		const clampedScrollOffset = Math.min(this.scrollOffset, maxScrollOffset);
+
+		let start = 0;
+		if (this.anchor === "bottom") {
+			start = Math.max(0, lines.length - viewportHeight - clampedScrollOffset);
+		} else {
+			start = clampedScrollOffset;
+		}
+
+		const sliced = lines.slice(start, start + viewportHeight);
+		while (sliced.length < viewportHeight) {
+			sliced.push("");
+		}
+		return sliced;
+	}
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -27,6 +27,7 @@ export { type SettingItem, SettingsList, type SettingsListTheme } from "./compon
 export { Spacer } from "./components/spacer.js";
 export { Text } from "./components/text.js";
 export { TruncatedText } from "./components/truncated-text.js";
+export { Viewport, type ViewportAnchor } from "./components/viewport.js";
 // Editor component interface (for custom editors)
 export type { EditorComponent } from "./editor-component.js";
 // Fuzzy matching

--- a/packages/tui/test/viewport-cache.test.ts
+++ b/packages/tui/test/viewport-cache.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Viewport } from "../src/components/viewport.js";
+
+describe("Viewport", () => {
+	it("clips transcript content inside a bottom-anchored viewport", () => {
+		const viewport = new Viewport(
+			{
+				render: () => ["1", "2", "3", "4", "5", "6"],
+				invalidate: () => {},
+			},
+			{ height: 3, anchor: "bottom" },
+		);
+
+		assert.deepStrictEqual(viewport.render(80), ["4", "5", "6"]);
+
+		viewport.setScrollOffset(2);
+
+		assert.deepStrictEqual(viewport.render(80), ["2", "3", "4"]);
+		assert.strictEqual(viewport.getMaxScrollOffset(), 3);
+	});
+
+	it("recomputes content height when the render width changes", () => {
+		const viewport = new Viewport(
+			{
+				render: (width: number) => (width < 10 ? ["one", "two", "three"] : ["wide"]),
+				invalidate: () => {},
+			},
+			{ height: 2 },
+		);
+
+		assert.deepStrictEqual(viewport.render(8), ["one", "two"]);
+		assert.strictEqual(viewport.getContentHeight(), 3);
+		assert.strictEqual(viewport.getMaxScrollOffset(), 1);
+
+		assert.deepStrictEqual(viewport.render(20), ["wide", ""]);
+		assert.strictEqual(viewport.getContentHeight(), 1);
+		assert.strictEqual(viewport.getMaxScrollOffset(), 0);
+	});
+
+	it("recomputes content height when the viewport height changes", () => {
+		const viewport = new Viewport(
+			{
+				render: () => ["one", "two", "three", "four"],
+				invalidate: () => {},
+			},
+			{ height: 3 },
+		);
+
+		assert.deepStrictEqual(viewport.render(20), ["one", "two", "three"]);
+		assert.strictEqual(viewport.getMaxScrollOffset(), 1);
+
+		viewport.setHeight(2);
+
+		assert.deepStrictEqual(viewport.render(20), ["one", "two"]);
+		assert.strictEqual(viewport.getContentHeight(), 4);
+		assert.strictEqual(viewport.getMaxScrollOffset(), 2);
+	});
+});


### PR DESCRIPTION
## Summary

- add a reusable Viewport component with top and bottom anchoring
- expose content height and max scroll offset for scrollable terminal regions
- export the component and add focused cache invalidation tests

## Validation

- node --test --import tsx test/viewport-cache.test.ts
- bun run check

Piper review issue: #11