### PR TITLE
Upstream proposal: restore terminal scroll modes

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -92,6 +92,10 @@ export class ProcessTerminal implements Terminal {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
 
+		// Switch to alternate screen buffer so trackpad/wheel scroll is delivered to the app
+		// instead of scrolling terminal history that can contain stale interactive frames.
+		process.stdout.write("\x1b[?1049h\x1b[2J\x1b[H");
+
 		// Save previous state and enable raw mode
 		this.wasRaw = process.stdin.isRaw || false;
 		if (process.stdin.setRawMode) {
@@ -102,6 +106,11 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
+
+		// Enable alternate scroll mode (?1007h) so scroll wheel events are delivered as
+		// Up/Down cursor key sequences. Clear motion/button tracking modes first to avoid
+		// inheriting stale state from a previous terminal app.
+		process.stdout.write("\x1b[?1002l\x1b[?1003l\x1b[?1000l\x1b[?1006l\x1b[?1007h");
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -275,6 +284,10 @@ export class ProcessTerminal implements Terminal {
 
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
+
+		// Disable mouse/scroll modes and restore main screen buffer.
+		process.stdout.write("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1007l");
+		process.stdout.write("\x1b[?1049l");
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this._kittyProtocolActive) {

--- a/packages/tui/test/process-terminal-mouse-mode.test.ts
+++ b/packages/tui/test/process-terminal-mouse-mode.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { ProcessTerminal } from "../src/terminal.js";
+
+type StdoutLike = NodeJS.WriteStream & {
+	write: (chunk: string | Uint8Array) => boolean;
+	on: (event: string, listener: (...args: unknown[]) => void) => NodeJS.WriteStream;
+	removeListener: (event: string, listener: (...args: unknown[]) => void) => NodeJS.WriteStream;
+	columns: number;
+	rows: number;
+};
+
+type StdinLike = NodeJS.ReadStream & {
+	isRaw?: boolean;
+	setRawMode?: (raw: boolean) => void;
+	setEncoding: (encoding: BufferEncoding) => void;
+	resume: () => void;
+	pause: () => void;
+	on: (event: string, listener: (...args: unknown[]) => void) => NodeJS.ReadStream;
+	removeListener: (event: string, listener: (...args: unknown[]) => void) => NodeJS.ReadStream;
+};
+
+describe("ProcessTerminal mouse mode", () => {
+	const originalStdout = process.stdout;
+	const originalStdin = process.stdin;
+	const originalKill = process.kill;
+	const originalSetTimeout = global.setTimeout;
+
+	let writes: string[];
+	let stdoutListeners: Array<{ event: string; listener: (...args: unknown[]) => void }>;
+	let stdinListeners: Array<{ event: string; listener: (...args: unknown[]) => void }>;
+	let rawModes: boolean[];
+	let terminal: ProcessTerminal;
+
+	beforeEach(() => {
+		writes = [];
+		stdoutListeners = [];
+		stdinListeners = [];
+		rawModes = [];
+
+		const fakeStdout: StdoutLike = Object.assign(Object.create(originalStdout), {
+			columns: 120,
+			rows: 40,
+			write: (chunk: string | Uint8Array) => {
+				writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+				return true;
+			},
+			on: (event: string, listener: (...args: unknown[]) => void) => {
+				stdoutListeners.push({ event, listener });
+				return fakeStdout;
+			},
+			removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+				stdoutListeners = stdoutListeners.filter((entry) => entry.event !== event || entry.listener !== listener);
+				return fakeStdout;
+			},
+		});
+
+		const fakeStdin: StdinLike = Object.assign(Object.create(originalStdin), {
+			isRaw: false,
+			setRawMode: (raw: boolean) => {
+				rawModes.push(raw);
+			},
+			setEncoding: (_encoding: BufferEncoding) => {},
+			resume: () => {},
+			pause: () => {},
+			on: (event: string, listener: (...args: unknown[]) => void) => {
+				stdinListeners.push({ event, listener });
+				return fakeStdin;
+			},
+			removeListener: (event: string, listener: (...args: unknown[]) => void) => {
+				stdinListeners = stdinListeners.filter((entry) => entry.event !== event || entry.listener !== listener);
+				return fakeStdin;
+			},
+		});
+
+		Object.defineProperty(process, "stdout", { value: fakeStdout, configurable: true });
+		Object.defineProperty(process, "stdin", { value: fakeStdin, configurable: true });
+		Object.defineProperty(process, "kill", {
+			value: ((_pid: number, _signal?: NodeJS.Signals | number) => true) as typeof process.kill,
+			configurable: true,
+		});
+		Object.defineProperty(global, "setTimeout", {
+			value: ((_: (...args: unknown[]) => void, __?: number) => 0) as unknown as typeof setTimeout,
+			configurable: true,
+		});
+
+		terminal = new ProcessTerminal();
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "stdout", { value: originalStdout, configurable: true });
+		Object.defineProperty(process, "stdin", { value: originalStdin, configurable: true });
+		Object.defineProperty(process, "kill", { value: originalKill, configurable: true });
+		Object.defineProperty(global, "setTimeout", { value: originalSetTimeout, configurable: true });
+	});
+
+	it("enables alternate screen, bracketed paste, and ordered mouse tracking on start", () => {
+		terminal.start(
+			() => {},
+			() => {},
+		);
+
+		assert.ok(writes.includes("\x1b[?1049h\x1b[2J\x1b[H"));
+		assert.ok(writes.includes("\x1b[?2004h"));
+		assert.ok(writes.includes("\x1b[?1002l\x1b[?1003l\x1b[?1000l\x1b[?1006l\x1b[?1007h"));
+		assert.ok(writes.includes("\x1b[?u"));
+		assert.deepStrictEqual(rawModes, [true]);
+		assert.ok(stdoutListeners.some((entry) => entry.event === "resize"));
+		assert.ok(stdinListeners.some((entry) => entry.event === "data"));
+	});
+
+	it("disables mouse tracking and restores terminal state on stop", () => {
+		terminal.start(
+			() => {},
+			() => {},
+		);
+		writes = [];
+
+		terminal.stop();
+
+		assert.ok(writes.includes("\x1b[?2004l"));
+		assert.ok(writes.includes("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1007l"));
+		assert.ok(writes.includes("\x1b[?1049l"));
+		assert.deepStrictEqual(rawModes, [true, false]);
+	});
+});


### PR DESCRIPTION
## Summary

- enter alternate screen before starting the interactive terminal UI
- clear stale mouse tracking modes and enable alternate scroll mode
- restore mouse/scroll modes and the main screen buffer on stop
- add fake-stdio coverage for the emitted terminal sequences

## Validation

- node --test --import tsx test/process-terminal-mouse-mode.test.ts
- bun run check

Piper review issue: #10