### PR TITLE
Upstream proposal: reuse assistant streaming blocks

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -6,6 +6,12 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
+type VisibleBlock =
+	| { type: "text"; text: string }
+	| { type: "thinking"; thinking: string; hasVisibleContentAfter: boolean };
+
+type ContentBlockEntry = { type: "text" | "thinking"; component: Markdown | Text };
+
 /**
  * Component that renders a complete assistant message
  */
@@ -16,6 +22,7 @@ export class AssistantMessageComponent extends Container {
 	private hiddenThinkingLabel: string;
 	private lastMessage?: AssistantMessage;
 	private hasToolCalls = false;
+	private contentBlockComponents: ContentBlockEntry[] = [];
 
 	constructor(
 		message?: AssistantMessage,
@@ -41,6 +48,7 @@ export class AssistantMessageComponent extends Container {
 	override invalidate(): void {
 		super.invalidate();
 		if (this.lastMessage) {
+			this.contentBlockComponents = [];
 			this.updateContent(this.lastMessage);
 		}
 	}
@@ -48,6 +56,7 @@ export class AssistantMessageComponent extends Container {
 	setHideThinkingBlock(hide: boolean): void {
 		this.hideThinkingBlock = hide;
 		if (this.lastMessage) {
+			this.contentBlockComponents = [];
 			this.updateContent(this.lastMessage);
 		}
 	}
@@ -55,6 +64,7 @@ export class AssistantMessageComponent extends Container {
 	setHiddenThinkingLabel(label: string): void {
 		this.hiddenThinkingLabel = label;
 		if (this.lastMessage) {
+			this.contentBlockComponents = [];
 			this.updateContent(this.lastMessage);
 		}
 	}
@@ -72,70 +82,101 @@ export class AssistantMessageComponent extends Container {
 
 	updateContent(message: AssistantMessage): void {
 		this.lastMessage = message;
+		this.hasToolCalls = message.content.some((c) => c.type === "toolCall");
 
-		// Clear content container
-		this.contentContainer.clear();
+		const visibleBlocks = this.getVisibleBlocks(message);
 
-		const hasVisibleContent = message.content.some(
-			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
-		);
-
-		if (hasVisibleContent) {
-			this.contentContainer.addChild(new Spacer(1));
+		if (!this.tryUpdateInPlace(message, visibleBlocks)) {
+			this.fullRebuild(message, visibleBlocks);
 		}
+	}
 
-		// Render content in order
+	private getVisibleBlocks(message: AssistantMessage): VisibleBlock[] {
+		const result: VisibleBlock[] = [];
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && content.text.trim()) {
-				// Assistant text messages with no background - trim the text
-				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, this.markdownTheme));
+				result.push({ type: "text", text: content.text.trim() });
 			} else if (content.type === "thinking" && content.thinking.trim()) {
-				// Add spacing only when another visible assistant content block follows.
-				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
 				const hasVisibleContentAfter = message.content
 					.slice(i + 1)
 					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
+				result.push({ type: "thinking", thinking: content.thinking.trim(), hasVisibleContentAfter });
+			}
+		}
+		return result;
+	}
 
+	private tryUpdateInPlace(message: AssistantMessage, visibleBlocks: VisibleBlock[]): boolean {
+		if (message.stopReason === "aborted" || message.stopReason === "error") return false;
+		if (message.errorMessage) return false;
+		if (visibleBlocks.length === 0) return false;
+		if (visibleBlocks.length !== this.contentBlockComponents.length) return false;
+
+		for (let i = 0; i < visibleBlocks.length; i++) {
+			const block = visibleBlocks[i];
+			const cached = this.contentBlockComponents[i];
+			if (block.type !== cached.type) return false;
+			if (block.type === "text" && !(cached.component instanceof Markdown)) return false;
+			if (block.type === "thinking" && !this.hideThinkingBlock && !(cached.component instanceof Markdown))
+				return false;
+			if (block.type === "thinking" && this.hideThinkingBlock && !(cached.component instanceof Text)) return false;
+		}
+
+		for (let i = 0; i < visibleBlocks.length; i++) {
+			const block = visibleBlocks[i];
+			const cached = this.contentBlockComponents[i];
+			if (block.type === "text") {
+				(cached.component as Markdown).setText(block.text);
+			} else if (block.type === "thinking" && !this.hideThinkingBlock) {
+				(cached.component as Markdown).setText(block.thinking);
+			}
+		}
+		return true;
+	}
+
+	private fullRebuild(message: AssistantMessage, visibleBlocks: VisibleBlock[]): void {
+		this.contentBlockComponents = [];
+		this.contentContainer.clear();
+
+		if (visibleBlocks.length > 0) {
+			this.contentContainer.addChild(new Spacer(1));
+		}
+
+		for (const block of visibleBlocks) {
+			if (block.type === "text") {
+				const md = new Markdown(block.text, 1, 0, this.markdownTheme);
+				this.contentContainer.addChild(md);
+				this.contentBlockComponents.push({ type: "text", component: md });
+			} else if (block.type === "thinking") {
 				if (this.hideThinkingBlock) {
-					// Show static thinking label when hidden
-					this.contentContainer.addChild(
-						new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), 1, 0),
-					);
-					if (hasVisibleContentAfter) {
+					const label = new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), 1, 0);
+					this.contentContainer.addChild(label);
+					this.contentBlockComponents.push({ type: "thinking", component: label });
+					if (block.hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
 					}
 				} else {
-					// Thinking traces in thinkingText color, italic
-					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
-							color: (text: string) => theme.fg("thinkingText", text),
-							italic: true,
-						}),
-					);
-					if (hasVisibleContentAfter) {
+					const md = new Markdown(block.thinking, 1, 0, this.markdownTheme, {
+						color: (text: string) => theme.fg("thinkingText", text),
+						italic: true,
+					});
+					this.contentContainer.addChild(md);
+					this.contentBlockComponents.push({ type: "thinking", component: md });
+					if (block.hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
 					}
 				}
 			}
 		}
 
-		// Check if aborted - show after partial content
-		// But only if there are no tool calls (tool execution components will show the error)
-		const hasToolCalls = message.content.some((c) => c.type === "toolCall");
-		this.hasToolCalls = hasToolCalls;
-		if (!hasToolCalls) {
+		if (!this.hasToolCalls) {
 			if (message.stopReason === "aborted") {
 				const abortMessage =
 					message.errorMessage && message.errorMessage !== "Request was aborted"
 						? message.errorMessage
 						: "Operation aborted";
-				if (hasVisibleContent) {
-					this.contentContainer.addChild(new Spacer(1));
-				} else {
-					this.contentContainer.addChild(new Spacer(1));
-				}
+				this.contentContainer.addChild(new Spacer(1));
 				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), 1, 0));
 			} else if (message.stopReason === "error") {
 				const errorMsg = message.errorMessage || "Unknown error";

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -7,7 +7,10 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
-function createAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
 	return {
 		role: "assistant",
 		content,
@@ -24,7 +27,12 @@ function createAssistantMessage(content: AssistantMessage["content"]): Assistant
 		},
 		stopReason: "stop",
 		timestamp: Date.now(),
+		...overrides,
 	};
+}
+
+function getContentBlockComponents(component: AssistantMessageComponent): Array<{ component: unknown }> {
+	return (component as unknown as { contentBlockComponents: Array<{ component: unknown }> }).contentBlockComponents;
 }
 
 describe("AssistantMessageComponent", () => {
@@ -53,5 +61,48 @@ describe("AssistantMessageComponent", () => {
 		expect(rendered.includes(OSC133_ZONE_START)).toBe(false);
 		expect(rendered.includes(OSC133_ZONE_END)).toBe(false);
 		expect(rendered.includes(OSC133_ZONE_FINAL)).toBe(false);
+	});
+
+	test("updates streamed text in place when block structure is unchanged", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(createAssistantMessage([{ type: "text", text: "hello" }]));
+		const [initialBlock] = getContentBlockComponents(component);
+
+		component.updateContent(createAssistantMessage([{ type: "text", text: "hello world" }]));
+
+		expect(getContentBlockComponents(component)[0]?.component).toBe(initialBlock?.component);
+		expect(component.render(80).join("\n")).toContain("hello world");
+	});
+
+	test("updates visible thinking in place when block structure is unchanged", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "thinking", thinking: "thinking one" }]),
+		);
+		const [initialBlock] = getContentBlockComponents(component);
+
+		component.updateContent(createAssistantMessage([{ type: "thinking", thinking: "thinking two" }]));
+
+		expect(getContentBlockComponents(component)[0]?.component).toBe(initialBlock?.component);
+		expect(component.render(80).join("\n")).toContain("thinking two");
+	});
+
+	test("falls back to rebuild for aborted messages", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(createAssistantMessage([{ type: "text", text: "partial" }]));
+		const [initialBlock] = getContentBlockComponents(component);
+
+		component.updateContent(
+			createAssistantMessage([{ type: "text", text: "partial update" }], {
+				stopReason: "aborted",
+				errorMessage: "Request was aborted",
+			}),
+		);
+
+		expect(getContentBlockComponents(component)[0]?.component).not.toBe(initialBlock?.component);
+		expect(component.render(80).join("\n")).toContain("Operation aborted");
 	});
 });


### PR DESCRIPTION
## Summary

- cache visible assistant text/thinking blocks during streaming
- update compatible Markdown components in place instead of rebuilding the full tree
- keep full rebuild fallback for abort/error/structure changes
- cover text reuse, thinking reuse, and aborted fallback

## Validation

- bunx vitest --run test/assistant-message.test.ts
- bun run check

Piper review issue: #13