### PR TITLE
Upstream proposal: preserve interactive shell state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6664,7 +6664,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/node-domexception": {
@@ -6703,6 +6702,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/node-pty": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+			"integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-addon-api": "^7.1.0"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -8635,6 +8644,7 @@
 				"ignore": "^7.0.5",
 				"marked": "^15.0.12",
 				"minimatch": "^10.2.3",
+				"node-pty": "^1.1.0",
 				"proper-lockfile": "^4.1.2",
 				"strip-ansi": "^7.1.0",
 				"typebox": "^1.1.24",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -53,6 +53,7 @@
 		"ignore": "^7.0.5",
 		"marked": "^15.0.12",
 		"minimatch": "^10.2.3",
+		"node-pty": "^1.1.0",
 		"proper-lockfile": "^4.1.2",
 		"strip-ansi": "^7.1.0",
 		"typebox": "^1.1.24",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -58,6 +58,7 @@ import {
 } from "../../config.js";
 import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.js";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.js";
+import type { BashResult } from "../../core/bash-executor.js";
 import type {
 	AutocompleteProviderFactory,
 	ExtensionCommandContext,
@@ -129,6 +130,7 @@ import {
 	type ThemeColor,
 	theme,
 } from "./theme/theme.js";
+import { UserShellSession } from "./user-shell-session.js";
 
 /** Interface for components that can be expanded/collapsed */
 interface Expandable {
@@ -302,6 +304,7 @@ export class InteractiveMode {
 
 	// Track current bash execution component
 	private bashComponent: BashExecutionComponent | undefined = undefined;
+	private userShellSession: UserShellSession | undefined = undefined;
 
 	// Track pending bash components (shown in pending area, moved to chat on submit)
 	private pendingBashComponents: BashExecutionComponent[] = [];
@@ -2390,6 +2393,8 @@ export class InteractiveMode {
 		this.defaultEditor.onEscape = () => {
 			if (this.session.isStreaming) {
 				this.restoreQueuedMessagesToEditor({ abort: true });
+			} else if (this.userShellSession?.isCommandRunning) {
+				this.userShellSession.abortActiveCommand();
 			} else if (this.session.isBashRunning) {
 				this.session.abortBash();
 			} else if (this.isBashMode) {
@@ -2606,7 +2611,7 @@ export class InteractiveMode {
 				const isExcluded = text.startsWith("!!");
 				const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
 				if (command) {
-					if (this.session.isBashRunning) {
+					if (this.session.isBashRunning || this.userShellSession?.isCommandRunning) {
 						this.showWarning("A bash command is already running. Press Esc to cancel it first.");
 						this.editor.setText(text);
 						return;
@@ -5387,16 +5392,18 @@ export class InteractiveMode {
 		this.ui.requestRender();
 
 		try {
-			const result = await this.session.executeBash(
-				command,
-				(chunk) => {
-					if (this.bashComponent) {
-						this.bashComponent.appendOutput(chunk);
-						this.ui.requestRender();
-					}
-				},
-				{ excludeFromContext, operations: eventResult?.operations },
-			);
+			const onChunk = (chunk: string) => {
+				if (this.bashComponent) {
+					this.bashComponent.appendOutput(chunk);
+					this.ui.requestRender();
+				}
+			};
+			const result = eventResult?.operations
+				? await this.session.executeBash(command, onChunk, {
+						excludeFromContext,
+						operations: eventResult.operations,
+					})
+				: await this.executeUserShellCommand(command, onChunk, excludeFromContext);
 
 			if (this.bashComponent) {
 				this.bashComponent.setComplete(
@@ -5415,6 +5422,17 @@ export class InteractiveMode {
 
 		this.bashComponent = undefined;
 		this.ui.requestRender();
+	}
+
+	private async executeUserShellCommand(
+		command: string,
+		onChunk: (chunk: string) => void,
+		excludeFromContext: boolean,
+	): Promise<BashResult> {
+		this.userShellSession ??= new UserShellSession({ cwd: this.sessionManager.getCwd() });
+		const result = await this.userShellSession.execute(command, onChunk);
+		this.session.recordBashResult(command, result, { excludeFromContext });
+		return result;
 	}
 
 	private async handleCompactCommand(customInstructions?: string): Promise<void> {
@@ -5449,6 +5467,8 @@ export class InteractiveMode {
 			this.loadingAnimation = undefined;
 		}
 		this.clearExtensionTerminalInputListeners();
+		void this.userShellSession?.dispose();
+		this.userShellSession = undefined;
 		this.footer.dispose();
 		this.footerDataProvider.dispose();
 		if (this.unsubscribe) {

--- a/packages/coding-agent/src/modes/interactive/user-shell-session.ts
+++ b/packages/coding-agent/src/modes/interactive/user-shell-session.ts
@@ -1,0 +1,420 @@
+import { createWriteStream, promises as fs, type WriteStream } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import * as nodePty from "node-pty";
+import stripAnsi from "strip-ansi";
+import type { BashResult } from "../../core/bash-executor.js";
+import { DEFAULT_MAX_BYTES, truncateTail } from "../../core/tools/truncate.js";
+import { getShellConfig, getShellEnv, sanitizeBinaryOutput } from "../../utils/shell.js";
+
+const OUTPUT_BUFFER_BYTES = DEFAULT_MAX_BYTES * 2;
+const START_MARKER_PREFIX = "__PI_USER_SHELL_START__";
+const END_MARKER_PREFIX = "__PI_USER_SHELL_END__";
+const CANCEL_EXIT_CODE = 130;
+
+type ShellFamily = "posix" | "fish";
+
+type ActiveCommand = {
+	id: string;
+	started: boolean;
+	abortRequested: boolean;
+	scriptPath: string;
+	parseBuffer: string;
+	outputChunks: string[];
+	outputBytes: number;
+	totalBytes: number;
+	tempFilePath?: string;
+	tempFileStream?: WriteStream;
+	onChunk?: (chunk: string) => void;
+	resolve: (result: BashResult) => void;
+	reject: (error: Error) => void;
+};
+
+function getShellFamily(shellPath: string): ShellFamily {
+	const shellName = basename(shellPath).toLowerCase();
+	if (shellName === "fish") {
+		return "fish";
+	}
+	return "posix";
+}
+
+function getStartMarker(id: string): string {
+	return `${START_MARKER_PREFIX}${id}__`;
+}
+
+function getEndMarkerPrefix(id: string): string {
+	return `${END_MARKER_PREFIX}${id}__`;
+}
+
+function stripTrailingLineBreak(text: string): string {
+	return text.replace(/\r?\n$/, "");
+}
+
+function findLineEnd(text: string, fromIndex: number): number {
+	const lineFeedIndex = text.indexOf("\n", fromIndex);
+	if (lineFeedIndex === -1) {
+		return -1;
+	}
+	return lineFeedIndex + 1;
+}
+
+function quoteShellPath(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function createUserShellScript(command: string, id: string, family: ShellFamily): string {
+	const startMarker = getStartMarker(id);
+	const endMarker = getEndMarkerPrefix(id);
+
+	if (family === "fish") {
+		return [
+			`printf '%s\\n' '${startMarker}'`,
+			command,
+			"set -l __pi_exit $status",
+			"set -l __pi_cwd (pwd)",
+			`printf '%s\\t%s\\t%s\\n' '${endMarker}' "$__pi_exit" "$__pi_cwd"`,
+			"",
+		].join("\n");
+	}
+
+	return [
+		"__pi_finish() {",
+		'\t__pi_exit="$1"',
+		"\t__pi_cwd=$(pwd)",
+		`\tprintf '%s\\t%s\\t%s\\n' '${endMarker}' "$__pi_exit" "$__pi_cwd"`,
+		"\ttrap - INT",
+		"}",
+		"__pi_interrupted=''",
+		`trap '__pi_interrupted=${CANCEL_EXIT_CODE}' INT`,
+		`printf '%s\\n' '${startMarker}'`,
+		command,
+		"__pi_exit=$?",
+		'if [ -n "$__pi_interrupted" ]; then',
+		'\t__pi_exit="$__pi_interrupted"',
+		"fi",
+		'__pi_finish "$__pi_exit"',
+		"",
+	].join("\n");
+}
+
+export function parseUserShellEndLine(
+	line: string,
+	id: string,
+): { exitCode: number | undefined; cwd: string } | undefined {
+	const prefix = getEndMarkerPrefix(id);
+	if (!line.startsWith(prefix)) {
+		return undefined;
+	}
+
+	const [marker, exitCodeText = "", cwd = ""] = line.split("\t", 3);
+	if (marker !== prefix) {
+		return undefined;
+	}
+
+	const parsedExitCode = Number.parseInt(exitCodeText, 10);
+	return {
+		exitCode: Number.isFinite(parsedExitCode) ? parsedExitCode : undefined,
+		cwd,
+	};
+}
+
+export class UserShellSession {
+	private cwd: string;
+	private tempDir: string | undefined;
+	private shell: nodePty.IPty | undefined;
+	private shellExitDisposable: nodePty.IDisposable | undefined;
+	private shellDataDisposable: nodePty.IDisposable | undefined;
+	private activeCommand: ActiveCommand | undefined;
+	private executionQueue: Promise<unknown> = Promise.resolve();
+	private disposed = false;
+	private readonly shellPath: string;
+	private readonly shellFamily: ShellFamily;
+	private readonly onCwdChange?: (cwd: string) => void;
+
+	constructor(options: { cwd: string; onCwdChange?: (cwd: string) => void }) {
+		const { shell } = getShellConfig("user");
+		this.cwd = resolve(options.cwd);
+		this.shellPath = shell;
+		this.shellFamily = getShellFamily(shell);
+		this.onCwdChange = options.onCwdChange;
+	}
+
+	get isCommandRunning(): boolean {
+		return this.activeCommand !== undefined;
+	}
+
+	async execute(command: string, onChunk?: (chunk: string) => void): Promise<BashResult> {
+		const run = this.executionQueue.then(() => this.executeQueued(command, onChunk));
+		this.executionQueue = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		return run;
+	}
+
+	abortActiveCommand(): void {
+		if (!this.activeCommand || !this.shell) {
+			return;
+		}
+
+		this.activeCommand.abortRequested = true;
+		this.shell.write("\u0003");
+	}
+
+	async dispose(): Promise<void> {
+		this.disposed = true;
+		this.shellDataDisposable?.dispose();
+		this.shellDataDisposable = undefined;
+		this.shellExitDisposable?.dispose();
+		this.shellExitDisposable = undefined;
+		this.shell?.kill();
+		this.shell = undefined;
+		this.activeCommand = undefined;
+		if (this.tempDir) {
+			await fs.rm(this.tempDir, { recursive: true, force: true });
+			this.tempDir = undefined;
+		}
+	}
+
+	private async executeQueued(command: string, onChunk?: (chunk: string) => void): Promise<BashResult> {
+		if (this.disposed) {
+			throw new Error("User shell session has been disposed");
+		}
+
+		await this.ensureShell();
+		const id = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+		const scriptPath = await this.writeScriptFile(id, command);
+
+		return await new Promise<BashResult>((resolve, reject) => {
+			if (!this.shell) {
+				reject(new Error("Shell exited before command could be sent"));
+				return;
+			}
+
+			this.activeCommand = {
+				id,
+				started: false,
+				abortRequested: false,
+				scriptPath,
+				parseBuffer: "",
+				outputChunks: [],
+				outputBytes: 0,
+				totalBytes: 0,
+				onChunk,
+				resolve,
+				reject,
+			};
+
+			try {
+				this.shell.write(`${this.getSourceCommand(scriptPath)}\r`);
+			} catch (err) {
+				this.activeCommand = undefined;
+				reject(new Error(`Failed to send command to shell: ${err instanceof Error ? err.message : String(err)}`));
+			}
+		});
+	}
+
+	private async ensureShell(): Promise<void> {
+		if (this.shell) {
+			return;
+		}
+
+		this.tempDir ??= await fs.mkdtemp(join(tmpdir(), "pi-user-shell-"));
+		this.shell = nodePty.spawn(this.shellPath, ["-i"], {
+			name: process.env.TERM || "xterm-256color",
+			cols: process.stdout.columns || 80,
+			rows: process.stdout.rows || 24,
+			cwd: this.cwd,
+			env: getShellEnv(),
+		});
+
+		this.shellDataDisposable = this.shell.onData((data) => {
+			this.handleShellData(data);
+		});
+		this.shellExitDisposable = this.shell.onExit(({ exitCode }) => {
+			const activeCommand = this.activeCommand;
+			this.shellDataDisposable?.dispose();
+			this.shellDataDisposable = undefined;
+			this.shellExitDisposable?.dispose();
+			this.shellExitDisposable = undefined;
+			this.shell = undefined;
+			if (!activeCommand) {
+				return;
+			}
+			void this.completeActiveCommand(exitCode, activeCommand.abortRequested);
+		});
+	}
+
+	private async writeScriptFile(id: string, command: string): Promise<string> {
+		this.tempDir ??= await fs.mkdtemp(join(tmpdir(), "pi-user-shell-"));
+		const extension = this.shellFamily === "fish" ? "fish" : "sh";
+		const scriptPath = join(this.tempDir, `command-${id}.${extension}`);
+		await fs.writeFile(scriptPath, createUserShellScript(command, id, this.shellFamily), "utf8");
+		return scriptPath;
+	}
+
+	private getSourceCommand(scriptPath: string): string {
+		const quotedPath = quoteShellPath(scriptPath);
+		if (this.shellFamily === "fish") {
+			return `source ${quotedPath}`;
+		}
+		return `. ${quotedPath}`;
+	}
+
+	private handleShellData(data: string): void {
+		const activeCommand = this.activeCommand;
+		if (!activeCommand) {
+			return;
+		}
+
+		activeCommand.parseBuffer += data;
+		if (!activeCommand.started) {
+			const startMarker = getStartMarker(activeCommand.id);
+			const markerIndex = activeCommand.parseBuffer.indexOf(startMarker);
+			if (markerIndex === -1) {
+				activeCommand.parseBuffer = activeCommand.parseBuffer.slice(-startMarker.length);
+				return;
+			}
+
+			const lineEnd = findLineEnd(activeCommand.parseBuffer, markerIndex + startMarker.length);
+			if (lineEnd === -1) {
+				return;
+			}
+
+			activeCommand.started = true;
+			activeCommand.parseBuffer = activeCommand.parseBuffer.slice(lineEnd);
+		}
+
+		this.flushActiveCommandOutput();
+	}
+
+	private flushActiveCommandOutput(): void {
+		const activeCommand = this.activeCommand;
+		if (!activeCommand || !activeCommand.started) {
+			return;
+		}
+
+		const endMarkerPrefix = getEndMarkerPrefix(activeCommand.id);
+		while (true) {
+			const markerIndex = activeCommand.parseBuffer.indexOf(endMarkerPrefix);
+			if (markerIndex === -1) {
+				const tailSize = endMarkerPrefix.length + 4096;
+				const emitLength = Math.max(0, activeCommand.parseBuffer.length - tailSize);
+				if (emitLength > 0) {
+					this.appendCommandOutput(activeCommand, activeCommand.parseBuffer.slice(0, emitLength));
+					activeCommand.parseBuffer = activeCommand.parseBuffer.slice(emitLength);
+				}
+				return;
+			}
+
+			if (markerIndex > 0) {
+				this.appendCommandOutput(activeCommand, activeCommand.parseBuffer.slice(0, markerIndex));
+			}
+
+			const lineEnd = findLineEnd(activeCommand.parseBuffer, markerIndex + endMarkerPrefix.length);
+			if (lineEnd === -1) {
+				activeCommand.parseBuffer = activeCommand.parseBuffer.slice(markerIndex);
+				return;
+			}
+
+			const endLine = stripTrailingLineBreak(activeCommand.parseBuffer.slice(markerIndex, lineEnd));
+			const parsedLine = parseUserShellEndLine(endLine, activeCommand.id);
+			activeCommand.parseBuffer = activeCommand.parseBuffer.slice(lineEnd);
+			if (!parsedLine) {
+				this.appendCommandOutput(activeCommand, `${endLine}\n`);
+				continue;
+			}
+
+			void this.completeActiveCommand(parsedLine.exitCode, activeCommand.abortRequested, parsedLine.cwd);
+			return;
+		}
+	}
+
+	private appendCommandOutput(activeCommand: ActiveCommand, chunk: string): void {
+		if (!chunk) {
+			return;
+		}
+
+		const sanitizedChunk = sanitizeBinaryOutput(stripAnsi(chunk)).replace(/\r/g, "");
+		if (!sanitizedChunk) {
+			return;
+		}
+
+		activeCommand.totalBytes += sanitizedChunk.length;
+		if (activeCommand.totalBytes > DEFAULT_MAX_BYTES) {
+			this.ensureTempFile(activeCommand);
+		}
+
+		if (activeCommand.tempFileStream) {
+			activeCommand.tempFileStream.write(sanitizedChunk);
+		}
+
+		activeCommand.outputChunks.push(sanitizedChunk);
+		activeCommand.outputBytes += sanitizedChunk.length;
+		while (activeCommand.outputBytes > OUTPUT_BUFFER_BYTES && activeCommand.outputChunks.length > 1) {
+			const removed = activeCommand.outputChunks.shift() ?? "";
+			activeCommand.outputBytes -= removed.length;
+		}
+
+		activeCommand.onChunk?.(sanitizedChunk);
+	}
+
+	private ensureTempFile(activeCommand: ActiveCommand): void {
+		if (activeCommand.tempFilePath) {
+			return;
+		}
+
+		activeCommand.tempFilePath = join(this.tempDir ?? tmpdir(), `pi-user-shell-output-${activeCommand.id}.log`);
+		activeCommand.tempFileStream = createWriteStream(activeCommand.tempFilePath);
+		for (const chunk of activeCommand.outputChunks) {
+			activeCommand.tempFileStream.write(chunk);
+		}
+	}
+
+	private closeTempFileStream(activeCommand: ActiveCommand): void {
+		const tempFileStream = activeCommand.tempFileStream;
+		tempFileStream?.end();
+		activeCommand.tempFileStream = undefined;
+	}
+
+	private async completeActiveCommand(
+		exitCode: number | undefined,
+		cancelled: boolean,
+		cwd: string = this.cwd,
+	): Promise<void> {
+		const activeCommand = this.activeCommand;
+		if (!activeCommand) {
+			return;
+		}
+
+		this.activeCommand = undefined;
+		this.closeTempFileStream(activeCommand);
+
+		const fullOutput = activeCommand.outputChunks.join("");
+		const truncationResult = truncateTail(fullOutput);
+		if (truncationResult.truncated) {
+			this.ensureTempFile(activeCommand);
+			this.closeTempFileStream(activeCommand);
+		}
+
+		try {
+			await fs.unlink(activeCommand.scriptPath);
+		} catch {
+			// Best-effort cleanup only.
+		}
+
+		const resolvedCwd = resolve(cwd || this.cwd);
+		if (resolvedCwd !== this.cwd) {
+			this.cwd = resolvedCwd;
+			this.onCwdChange?.(resolvedCwd);
+		}
+
+		activeCommand.resolve({
+			output: truncationResult.truncated ? truncationResult.content : fullOutput,
+			exitCode,
+			cancelled,
+			truncated: truncationResult.truncated,
+			fullOutputPath: activeCommand.tempFilePath,
+		});
+	}
+}

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -2,10 +2,44 @@ import { existsSync } from "node:fs";
 import { delimiter } from "node:path";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.js";
+import { SettingsManager } from "../core/settings-manager.js";
 
 export interface ShellConfig {
 	shell: string;
 	args: string[];
+}
+
+export type ShellExecutionMode = "tool" | "user";
+
+let cachedShellConfigs = new Map<ShellExecutionMode, ShellConfig>();
+
+function getShellBasename(shellPath: string): string {
+	const normalized = shellPath.replace(/\\/g, "/");
+	return normalized.split("/").pop()?.toLowerCase() ?? normalized.toLowerCase();
+}
+
+export function getShellArgs(shellPath: string, mode: ShellExecutionMode): string[] {
+	if (mode === "tool") {
+		return ["-c"];
+	}
+
+	const shell = getShellBasename(shellPath);
+	if (
+		shell === "bash" ||
+		shell === "zsh" ||
+		shell === "fish" ||
+		shell === "ksh" ||
+		shell === "mksh" ||
+		shell === "pdksh" ||
+		shell === "csh" ||
+		shell === "tcsh" ||
+		shell === "nu" ||
+		shell === "nushell"
+	) {
+		return ["-i", "-c"];
+	}
+
+	return ["-c"];
 }
 
 /**
@@ -46,17 +80,47 @@ function findBashOnPath(): string | null {
 /**
  * Resolve shell configuration based on platform and an optional explicit shell path.
  * Resolution order:
- * 1. User-specified shellPath
+ * 1. Explicit shell path argument
  * 2. On Windows: Git Bash in known locations, then bash on PATH
  * 3. On Unix: /bin/bash, then bash on PATH, then fallback to sh
+ *
+ * User mode:
+ * 1. User-specified shellPath in settings.json
+ * 2. On Unix: $SHELL when it exists
+ * 3. Fall back to tool-mode resolution
  */
-export function getShellConfig(customShellPath?: string): ShellConfig {
-	// 1. Check user-specified shell path
+export function getShellConfig(modeOrShellPath: ShellExecutionMode | string = "tool"): ShellConfig {
+	const mode: ShellExecutionMode = modeOrShellPath === "user" ? "user" : "tool";
+	const explicitShellPath = modeOrShellPath === "tool" || modeOrShellPath === "user" ? undefined : modeOrShellPath;
+
+	if (!explicitShellPath) {
+		const cached = cachedShellConfigs.get(mode);
+		if (cached) {
+			return cached;
+		}
+	}
+
+	const settings = mode === "user" && !explicitShellPath ? SettingsManager.create(process.cwd()) : undefined;
+	const customShellPath = explicitShellPath ?? settings?.getShellPath();
+
 	if (customShellPath) {
 		if (existsSync(customShellPath)) {
-			return { shell: customShellPath, args: ["-c"] };
+			const config = { shell: customShellPath, args: getShellArgs(customShellPath, mode) };
+			if (!explicitShellPath) {
+				cachedShellConfigs.set(mode, config);
+			}
+			return config;
 		}
 		throw new Error(`Custom shell path not found: ${customShellPath}`);
+	}
+
+	if (mode === "user" && process.platform !== "win32") {
+		const envShell = process.env.SHELL;
+		if (envShell && existsSync(envShell)) {
+			const config = { shell: envShell, args: getShellArgs(envShell, mode) };
+			cachedShellConfigs.set(mode, config);
+			return config;
+		}
 	}
 
 	if (process.platform === "win32") {
@@ -73,14 +137,18 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 
 		for (const path of paths) {
 			if (existsSync(path)) {
-				return { shell: path, args: ["-c"] };
+				const config = { shell: path, args: getShellArgs(path, mode) };
+				cachedShellConfigs.set(mode, config);
+				return config;
 			}
 		}
 
 		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
 		const bashOnPath = findBashOnPath();
 		if (bashOnPath) {
-			return { shell: bashOnPath, args: ["-c"] };
+			const config = { shell: bashOnPath, args: getShellArgs(bashOnPath, mode) };
+			cachedShellConfigs.set(mode, config);
+			return config;
 		}
 
 		throw new Error(
@@ -94,15 +162,25 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 
 	// Unix: try /bin/bash, then bash on PATH, then fallback to sh
 	if (existsSync("/bin/bash")) {
-		return { shell: "/bin/bash", args: ["-c"] };
+		const config = { shell: "/bin/bash", args: getShellArgs("/bin/bash", mode) };
+		cachedShellConfigs.set(mode, config);
+		return config;
 	}
 
 	const bashOnPath = findBashOnPath();
 	if (bashOnPath) {
-		return { shell: bashOnPath, args: ["-c"] };
+		const config = { shell: bashOnPath, args: getShellArgs(bashOnPath, mode) };
+		cachedShellConfigs.set(mode, config);
+		return config;
 	}
 
-	return { shell: "sh", args: ["-c"] };
+	const config = { shell: "sh", args: getShellArgs("sh", mode) };
+	cachedShellConfigs.set(mode, config);
+	return config;
+}
+
+export function resetShellConfigCache(): void {
+	cachedShellConfigs = new Map();
 }
 
 export function getShellEnv(): NodeJS.ProcessEnv {

--- a/packages/coding-agent/test/user-shell-session.test.ts
+++ b/packages/coding-agent/test/user-shell-session.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createUserShellScript, parseUserShellEndLine } from "../src/modes/interactive/user-shell-session.js";
+
+describe("createUserShellScript", () => {
+	it("wraps posix commands with start/end markers and interrupt handling", () => {
+		const script = createUserShellScript("cd ../repo\npwd", "cmd-1", "posix");
+
+		expect(script).toContain("__PI_USER_SHELL_START__cmd-1__");
+		expect(script).toContain("__PI_USER_SHELL_END__cmd-1__");
+		expect(script).toContain("trap '__pi_interrupted=130' INT");
+		expect(script).toContain("cd ../repo");
+	});
+
+	it("wraps fish commands with fish status tracking", () => {
+		const script = createUserShellScript("cd ../repo\npwd", "cmd-2", "fish");
+
+		expect(script).toContain("__PI_USER_SHELL_START__cmd-2__");
+		expect(script).toContain("__PI_USER_SHELL_END__cmd-2__");
+		expect(script).toContain("set -l __pi_exit $status");
+		expect(script).toContain("set -l __pi_cwd (pwd)");
+	});
+});
+
+describe("parseUserShellEndLine", () => {
+	it("parses exit code and cwd from the command footer", () => {
+		const parsed = parseUserShellEndLine("__PI_USER_SHELL_END__cmd-3__\t7\t/tmp/my repo", "cmd-3");
+
+		expect(parsed).toEqual({
+			exitCode: 7,
+			cwd: "/tmp/my repo",
+		});
+	});
+
+	it("returns undefined for lines from a different command", () => {
+		expect(parseUserShellEndLine("__PI_USER_SHELL_END__other__\t0\t/tmp", "cmd-4")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- add a PTY-backed `UserShellSession` for interactive bang commands
- keep tool and extension bash operations on the existing `AgentSession` path
- preserve shell cwd across subsequent `!` commands and support abort/output truncation
- add wrapper and marker parsing coverage for POSIX and fish shells

## Validation

- `bunx vitest --run test/user-shell-session.test.ts`
- `bun run check`

Piper review issue: #14
